### PR TITLE
Initialize project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # go-api-template-clean
+
+Este repositório apresenta uma estrutura base para APIs em Go.
+Consulte o diretório [`docs`](docs/README.md) para detalhes de arquitetura e instruções de uso.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,10 @@
+package main
+
+// Entry point of the application.
+// Loads the dependency container, sets up routes and starts HTTP server.
+
+func main() {
+	// TODO: initialize dependency container
+	// TODO: initialize routes
+	// TODO: start HTTP server
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS
+
+Este arquivo orienta o uso de IA na expansão do projeto.
+
+## Exemplo de prompt para criação de novos módulos
+
+```
+Crie um novo módulo de domínio seguindo a estrutura do projeto. Gere entidade, repositório, serviço, usecase e handler correspondentes, aplicando princípios SOLID e mantendo a independência de infraestrutura.
+```
+
+## Checklist de validação SOLID
+
+- [ ] **Single Responsibility**: cada módulo possui apenas uma responsabilidade?
+- [ ] **Open/Closed**: novas funcionalidades exigem modificação mínima em código existente?
+- [ ] **Liskov Substitution**: interfaces são respeitadas por implementações?
+- [ ] **Interface Segregation**: dependências expõem apenas o necessário?
+- [ ] **Dependency Inversion**: detalhes dependem de abstrações e não o contrário?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Go API Template Clean
+
+## Objetivo do template
+
+Este projeto provê uma base para construção de APIs em Go utilizando Clean Architecture e princípios SOLID. A estrutura visa facilitar a evolução modular e independente de infraestrutura, além de permitir testes unitários isolados.
+
+## Design Patterns Principais
+
+- Dependency Injection
+- Repository
+- Service
+- Use Case (Interactor)
+- Middleware como Função
+
+## Arquitetura
+
+O código é organizado no diretório `internal`, separando domínio, camadas de aplicação e infraestrutura. Use cases interagem com repositórios através de interfaces, garantindo que mudanças em bancos ou serviços externos não afetem o domínio. Handlers expõem as funcionalidades via HTTP e utilizam middlewares compostáveis.
+
+```
+cmd/            # ponto de entrada da aplicação
+internal/
+  config/       # carregamento de configurações
+  domain/       # regras de negócio e entidades
+  handler/      # handlers HTTP
+  usecase/      # casos de uso
+  repository/   # interfaces de repositório
+  service/      # serviços de domínio
+  infra/        # implementações de infraestrutura (db, email, cache)
+  routes/       # roteamento da aplicação
+  middleware/   # middlewares HTTP
+  app/          # container de dependências
+pkg/            # utilidades e contratos externos
+```
+
+## Como iniciar o projeto
+
+1. Crie um módulo Go:
+
+```bash
+go mod init github.com/seuusuario/go-api-template-clean
+```
+
+2. Construa o container de dependências e inicialize o servidor:
+
+```bash
+go run ./cmd
+```
+
+## Como estender
+
+- Adicione novos casos de uso em `internal/usecase`
+- Implemente repositórios concretos em `internal/infra` e referencie interfaces em `internal/repository`
+- Utilize middlewares em `internal/middleware` compondo as rotas em `internal/routes`
+
+## Criando novos módulos
+
+Siga o padrão existente para adicionar novas funcionalidades. Utilize o arquivo `docs/AGENTS.md` como referência para prompts de criação automática e checklist de aderência aos princípios SOLID.

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -1,0 +1,16 @@
+package app
+
+// container.go centralizes dependency injection.
+// Example functions illustrate how services and handlers would be constructed.
+
+// NewExampleService provides an instance of ExampleService with injected dependencies.
+func NewExampleService() interface{} {
+	// TODO: construct service dependencies
+	return nil
+}
+
+// NewExampleHandler provides an instance of ExampleHandler using explicit injection.
+func NewExampleHandler(service interface{}) interface{} {
+	// TODO: construct handler with service
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,14 @@
+package config
+
+// config.go loads environment variables and exposes configuration structs.
+// Configurations should be reusable and provided via interfaces.
+
+type AppConfig struct {
+	// TODO: define configuration fields, e.g., server port
+}
+
+// Load reads environment variables into Config structs.
+func Load() (*AppConfig, error) {
+	// TODO: load and return configuration
+	return &AppConfig{}, nil
+}


### PR DESCRIPTION
## Summary
- set up go-api-template-clean project skeleton
- add docs with architecture overview and agent instructions
- implement placeholders for config, container and main

## Testing
- `gofmt -w cmd/main.go internal/app/container.go internal/config/config.go`


------
https://chatgpt.com/codex/tasks/task_e_68784153bf54832b82f2eae970ff621c