### PR TITLE
Implement basic domain layer with User modules

### DIFF
--- a/internal/domain/entity/user.go
+++ b/internal/domain/entity/user.go
@@ -1,0 +1,20 @@
+package entity
+
+import (
+	"regexp"
+	"time"
+)
+
+// User represents a system user with basic attributes.
+type User struct {
+	ID        string
+	Name      string
+	Email     string
+	CreatedAt time.Time
+}
+
+// IsValidEmail performs a basic regex validation of the user's email.
+func (u *User) IsValidEmail() bool {
+	pattern := `^[a-zA-Z0-9_.%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`
+	return regexp.MustCompile(pattern).MatchString(u.Email)
+}

--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -1,0 +1,10 @@
+package repository
+
+import "github.com/seuusuario/go-api-template-clean/internal/domain/entity"
+
+// UserRepository defines persistence operations for User entities.
+type UserRepository interface {
+	FindByID(id string) (*entity.User, error)
+	Save(user *entity.User) error
+	Delete(id string) error
+}

--- a/internal/domain/service/user_service.go
+++ b/internal/domain/service/user_service.go
@@ -1,0 +1,9 @@
+package service
+
+import "github.com/seuusuario/go-api-template-clean/internal/domain/entity"
+
+// UserService exposes user-related business operations.
+type UserService interface {
+	RegisterUser(name, email string) (*entity.User, error)
+	RemoveUser(id string) error
+}

--- a/internal/domain/usecase/user_usecase.go
+++ b/internal/domain/usecase/user_usecase.go
@@ -1,0 +1,57 @@
+package usecase
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/seuusuario/go-api-template-clean/internal/domain/entity"
+	"github.com/seuusuario/go-api-template-clean/internal/domain/repository"
+	"github.com/seuusuario/go-api-template-clean/internal/domain/service"
+)
+
+// UserUseCase implements UserService, orchestrating business logic.
+type UserUseCase struct {
+	repo repository.UserRepository
+}
+
+// NewUserUseCase creates a new UserUseCase with its required repository.
+func NewUserUseCase(repo repository.UserRepository) *UserUseCase {
+	return &UserUseCase{repo: repo}
+}
+
+// RegisterUser creates a new user after validating the email.
+func (uc *UserUseCase) RegisterUser(name, email string) (*entity.User, error) {
+	user := &entity.User{
+		ID:        generateID(),
+		Name:      name,
+		Email:     email,
+		CreatedAt: time.Now(),
+	}
+
+	if !user.IsValidEmail() {
+		return nil, fmt.Errorf("invalid email")
+	}
+
+	if err := uc.repo.Save(user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+// RemoveUser deletes the user by id.
+func (uc *UserUseCase) RemoveUser(id string) error {
+	return uc.repo.Delete(id)
+}
+
+// Ensure UserUseCase satisfies UserService at compile time.
+var _ service.UserService = (*UserUseCase)(nil)
+
+func generateID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
## Summary
- add `User` entity with basic fields and email validation
- define `UserRepository` interface for persistence contracts
- define `UserService` interface for business operations
- implement `UserUseCase` that orchestrates user creation and removal

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687847586218832b898b59b7baf510bc