### PR TITLE
Implement environment config loader

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ import (
 // It loads the configuration, builds the dependency container, registers the
 // routes and finally starts the HTTP server.
 func main() {
-	cfg, err := config.Load()
+	cfg, err := config.LoadConfig()
 	if err != nil {
 		log.Fatalf("failed to load configuration: %v", err)
 	}
@@ -26,8 +26,8 @@ func main() {
 	router.Use(httpmiddleware.LoggerMiddleware)
 	registerRoutes(router, container)
 
-	// Use configured address for the HTTP server.
-	addr := cfg.ServerAddr
+	// Use configured port for the HTTP server.
+	addr := ":" + cfg.Port
 
 	log.Printf("starting HTTP server on %s", addr)
 	if err := http.ListenAndServe(addr, router); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,22 +1,73 @@
 package config
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
 
-// config.go loads environment variables and exposes configuration structs.
-// Configurations should be reusable and provided via interfaces.
-
-// AppConfig holds basic application configuration such as the HTTP server
-// address. Additional configuration fields can be added as the project grows.
+// AppConfig holds all configurable parameters of the application. It is loaded
+// from environment variables in a centralized manner so the rest of the
+// application can simply depend on this struct.
 type AppConfig struct {
-	ServerAddr string
+	Env          string
+	Port         string
+	DatabaseURL  string
+	RedisURL     string
+	SMTPHost     string
+	SMTPPort     int
+	SMTPUser     string
+	SMTPPassword string
 }
 
-// Load reads environment variables and returns an AppConfig populated with
-// sensible defaults when values are not provided.
-func Load() (*AppConfig, error) {
-	addr := os.Getenv("HTTP_ADDR")
-	if addr == "" {
-		addr = ":8080"
+// LoadConfig reads the required environment variables, sets default values for
+// optional ones and validates mandatory fields. It returns an AppConfig instance
+// ready to be consumed by the application.
+func LoadConfig() (*AppConfig, error) {
+	cfg := &AppConfig{}
+
+	// Environment the application is running in. Defaults to "dev" when not
+	// provided.
+	env := os.Getenv("APP_ENV")
+	if env == "" {
+		env = "dev"
 	}
-	return &AppConfig{ServerAddr: addr}, nil
+	cfg.Env = env
+
+	// HTTP port the server should listen on. Defaults to 8080.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	cfg.Port = port
+
+	// Mandatory fields.
+	cfg.DatabaseURL = os.Getenv("DATABASE_URL")
+	if cfg.DatabaseURL == "" {
+		return nil, fmt.Errorf("DATABASE_URL is required")
+	}
+
+	cfg.RedisURL = os.Getenv("REDIS_URL")
+
+	cfg.SMTPHost = os.Getenv("SMTP_HOST")
+
+	if v := os.Getenv("SMTP_PORT"); v != "" {
+		p, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SMTP_PORT: %w", err)
+		}
+		cfg.SMTPPort = p
+	} else {
+		cfg.SMTPPort = 587
+	}
+
+	cfg.SMTPUser = os.Getenv("SMTP_USER")
+	cfg.SMTPPassword = os.Getenv("SMTP_PASSWORD")
+
+	return cfg, nil
+}
+
+// IsProd indicates if the application is running in production environment.
+func (c *AppConfig) IsProd() bool {
+	return c.Env == "prod"
 }


### PR DESCRIPTION
## Summary
- expand AppConfig to cover env variables
- add LoadConfig() to parse env vars with defaults
- update `cmd/main.go` to use the new loader

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68784dd05d60832b882a8bfccd3445e6