### PR TITLE
docs: add detailed usage guide and AI conventions

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,17 +1,34 @@
 # AGENTS
 
-Este arquivo orienta o uso de IA na expansão do projeto.
+Este documento padroniza a forma de usar agentes de IA na evolução do projeto. Seu propósito é garantir que toda automação siga a arquitetura e os princípios definidos.
 
-## Exemplo de prompt para criação de novos módulos
-
+## Exemplo de Prompt
 ```
-Crie um novo módulo de domínio seguindo a estrutura do projeto. Gere entidade, repositório, serviço, usecase e handler correspondentes, aplicando princípios SOLID e mantendo a independência de infraestrutura.
+Crie um novo módulo chamado `Invoice` seguindo os mesmos padrões do módulo `User`:
+- `entity`
+- `repository` (interface)
+- `service` (interface)
+- `usecase` (implementação)
+- `handler` com endpoints REST
+- Registro de rotas e injeção no container
 ```
 
-## Checklist de validação SOLID
+## Checklist de Validação SOLID
+- A responsabilidade de cada struct está clara e única?
+- Alguma interface está sendo implementada forçadamente?
+- A lógica de domínio conhece detalhes técnicos da infraestrutura?
+- Algum handler ou usecase realiza mais de uma função?
+- As dependências são injetadas por abstrações?
 
-- [ ] **Single Responsibility**: cada módulo possui apenas uma responsabilidade?
-- [ ] **Open/Closed**: novas funcionalidades exigem modificação mínima em código existente?
-- [ ] **Liskov Substitution**: interfaces são respeitadas por implementações?
-- [ ] **Interface Segregation**: dependências expõem apenas o necessário?
-- [ ] **Dependency Inversion**: detalhes dependem de abstrações e não o contrário?
+Regras
+- O tom deve ser direto e técnico
+- Não incluir código, apenas estrutura, instruções e convenções
+
+⸻
+
+Padrões aplicados
+- SRP: cada documento tem uma função clara
+- Transparência e padronização para evoluções futuras
+
+Finalidade
+Documentar com clareza a estrutura, funcionamento e diretrizes do projeto, tornando possível sua adoção por múltiplos desenvolvedores e agentes de automação com mínima curva de aprendizado.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,57 +1,69 @@
 # Go API Template Clean
 
-## Objetivo do template
-
-Este projeto provê uma base para construção de APIs em Go utilizando Clean Architecture e princípios SOLID. A estrutura visa facilitar a evolução modular e independente de infraestrutura, além de permitir testes unitários isolados.
-
-## Design Patterns Principais
-
-- Dependency Injection
-- Repository
-- Service
-- Use Case (Interactor)
-- Middleware como Função
+## Visão Geral
+Este repositório fornece um ponto de partida para a criação de APIs em Go voltadas para escalabilidade e testes. Foi desenhado para desenvolvedores que desejam aplicar Clean Architecture e princípios SOLID desde os primeiros commits.
 
 ## Arquitetura
+A estrutura segue os conceitos da Clean Architecture onde regras de negócio ficam isoladas das camadas externas. Cada pacote expõe apenas aquilo que a camada superior necessita, favorecendo o uso de dependências injetadas por interfaces.
 
-O código é organizado no diretório `internal`, separando domínio, camadas de aplicação e infraestrutura. Use cases interagem com repositórios através de interfaces, garantindo que mudanças em bancos ou serviços externos não afetem o domínio. Handlers expõem as funcionalidades via HTTP e utilizam middlewares compostáveis.
+- **domain**: contém entidades e regras de negócio.
+- **infra**: implementa detalhes técnicos (banco, cache, email).
+- **handler**: camada de entrada, atualmente via HTTP.
+- **app**: compõe e injeta dependências entre as camadas.
 
+Essas separações reforçam os princípios SOLID, mantendo baixo acoplamento e alta coesão.
+
+## Padrões Utilizados
+- Factory
+- Adapter
+- Strategy
+- Middleware
+- Functional Options (planejado para usos futuros)
+- Interface Segregation
+- Dependency Inversion
+
+## Estrutura do Projeto
+```text
+.
+├── cmd/                  ponto de entrada da aplicação
+├── docs/                 documentação e guias
+├── internal/
+│   ├── app/              injeção de dependências
+│   ├── config/           carregamento de variáveis de ambiente
+│   ├── domain/           regras de negócio
+│   │   ├── entity/       modelos de domínio
+│   │   ├── repository/   contratos de persistência
+│   │   ├── service/      interfaces de serviços
+│   │   └── usecase/      orquestração de regras
+│   ├── handler/          camadas de entrada (HTTP)
+│   │   └── http/         handlers, rotas e middlewares
+│   └── infra/            implementações concretas (db, cache, email)
+└── pkg/                  utilidades e contratos externos
 ```
-cmd/            # ponto de entrada da aplicação
-internal/
-  config/       # carregamento de configurações
-  domain/       # regras de negócio e entidades
-  handler/      # handlers HTTP
-  usecase/      # casos de uso
-  repository/   # interfaces de repositório
-  service/      # serviços de domínio
-  infra/        # implementações de infraestrutura (db, email, cache)
-  routes/       # roteamento da aplicação
-  middleware/   # middlewares HTTP
-  app/          # container de dependências
-pkg/            # utilidades e contratos externos
-```
+Cada pasta possui responsabilidade única, facilitando testes unitários e extensões controladas.
 
-## Como iniciar o projeto
-
-1. Crie um módulo Go:
-
-```bash
-go mod init github.com/rgomids/go-api-template-clean
-```
-
-2. Construa o container de dependências e inicialize o servidor:
-
-```bash
+## Como Usar
+1. Clone o projeto e instale as dependências:
+   ```bash
+git clone <repo-url>
+cd go-api-template-clean
+go mod download
+   ```
+2. Configure as variáveis de ambiente conforme `internal/config`:
+   - `APP_ENV` (dev|prod)
+   - `PORT` (padrão 8080)
+   - `DATABASE_URL` (obrigatória)
+   - `REDIS_URL`
+   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`
+3. Execute a aplicação:
+   ```bash
 go run ./cmd
-```
+   ```
+   Quando um `Makefile` estiver disponível utilize `make build`, `make test` e `make run` para padronizar as etapas.
 
-## Como estender
-
-- Adicione novos casos de uso em `internal/usecase`
-- Implemente repositórios concretos em `internal/infra` e referencie interfaces em `internal/repository`
-- Utilize middlewares em `internal/middleware` compondo as rotas em `internal/routes`
-
-## Criando novos módulos
-
-Siga o padrão existente para adicionar novas funcionalidades. Utilize o arquivo `docs/AGENTS.md` como referência para prompts de criação automática e checklist de aderência aos princípios SOLID.
+## Como Estender
+- Crie novas entidades em `internal/domain/entity` e suas interfaces em `repository` ou `service`.
+- Implemente casos de uso em `usecase` mantendo a orquestração da lógica de negócio.
+- Adicione handlers e rotas em `internal/handler/http` e registre-os em `routes`.
+- Para cada nova dependência externa, forneça uma implementação em `internal/infra` e injete-a via `app`.
+- Utilize os padrões e a checklist de `docs/AGENTS.md` para garantir aderência aos princípios SOLID.


### PR DESCRIPTION
## Summary
- document project structure, architecture and usage in `docs/README.md`
- add AI guidance and SOLID checklist in `docs/AGENTS.md`

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878509e6c88832bb81ae0a4bcfb9961