### PR TITLE
Add Makefile and docker build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: help run dev lint fmt test build docker-dev docker-prod
+
+help:
+	@echo "Comandos disponíveis:"
+	@echo "  make run          - Executa a API localmente (modo padrão)"
+	@echo "  make dev          - Executa a API com variável ENV=dev"
+	@echo "  make test         - Executa os testes unitários"
+	@echo "  make lint         - Roda o linter (go vet + staticcheck)"
+	@echo "  make fmt          - Formata o código com go fmt"
+	@echo "  make build        - Compila o binário para o host local"
+	@echo "  make docker-dev   - Builda a imagem Docker de dev"
+	@echo "  make docker-prod  - Builda a imagem Docker de produção"
+
+run:
+	go run ./cmd/main.go
+
+dev:
+	ENV=dev go run ./cmd/main.go
+
+test:
+	go test ./... -v -cover
+
+lint:
+	go vet ./...
+	staticcheck ./...
+
+fmt:
+	go fmt ./...
+
+build:
+	go build -o bin/api ./cmd/main.go
+
+docker-dev:
+	docker build -f infra/docker/Dockerfile.dev -t go-api-template:dev .
+
+docker-prod:
+	docker build -f infra/docker/Dockerfile.prod -t go-api-template:prod .

--- a/infra/docker/Dockerfile.dev
+++ b/infra/docker/Dockerfile.dev
@@ -1,0 +1,5 @@
+# Development Dockerfile
+FROM golang:1.20-alpine
+WORKDIR /app
+COPY . .
+CMD ["go", "run", "./cmd/main.go"]

--- a/infra/docker/Dockerfile.prod
+++ b/infra/docker/Dockerfile.prod
@@ -1,0 +1,9 @@
+# Production Dockerfile
+FROM golang:1.20-alpine AS build
+WORKDIR /src
+COPY . .
+RUN go build -o /bin/api ./cmd/main.go
+
+FROM alpine:latest
+COPY --from=build /bin/api /bin/api
+CMD ["/bin/api"]


### PR DESCRIPTION
## Summary
- introduce Makefile with common development targets
- add Dockerfiles for dev and production images
- ignore generated binaries

## Testing
- `go fmt ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go build -o bin/api ./cmd/main.go`
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_687852409450832b95ca90033dab6e54