### PR TITLE
Add basic unit tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import "testing"
+
+func TestLoadConfigDefaults(t *testing.T) {
+	t.Setenv("DATABASE_URL", "db")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Env != "dev" {
+		t.Errorf("expected dev env, got %s", cfg.Env)
+	}
+	if cfg.Port != "8080" {
+		t.Errorf("expected default port 8080, got %s", cfg.Port)
+	}
+	if cfg.SMTPPort != 587 {
+		t.Errorf("expected default smtp port 587, got %d", cfg.SMTPPort)
+	}
+}
+
+func TestLoadConfigMissingDB(t *testing.T) {
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("expected error for missing DATABASE_URL")
+	}
+}
+
+func TestLoadConfigInvalidSMTPPort(t *testing.T) {
+	t.Setenv("DATABASE_URL", "db")
+	t.Setenv("SMTP_PORT", "bad")
+	if _, err := LoadConfig(); err == nil {
+		t.Fatal("expected error for invalid SMTP_PORT")
+	}
+}

--- a/internal/domain/entity/user_test.go
+++ b/internal/domain/entity/user_test.go
@@ -1,0 +1,26 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/rgomids/go-api-template-clean/internal/domain/entity"
+)
+
+func TestUserIsValidEmail(t *testing.T) {
+	cases := []struct {
+		email string
+		valid bool
+	}{
+		{"test@example.com", true},
+		{"user+label@domain.co", true},
+		{"invalid-email", false},
+		{"@missinguser.com", false},
+	}
+
+	for _, c := range cases {
+		u := &entity.User{Email: c.email}
+		if got := u.IsValidEmail(); got != c.valid {
+			t.Errorf("IsValidEmail(%q) = %v, want %v", c.email, got, c.valid)
+		}
+	}
+}

--- a/internal/domain/usecase/user_usecase_test.go
+++ b/internal/domain/usecase/user_usecase_test.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rgomids/go-api-template-clean/internal/domain/entity"
+)
+
+type stubRepo struct {
+	saved     *entity.User
+	deleted   string
+	saveErr   error
+	deleteErr error
+}
+
+func (s *stubRepo) FindByID(id string) (*entity.User, error) { return nil, nil }
+func (s *stubRepo) Save(u *entity.User) error {
+	s.saved = u
+	return s.saveErr
+}
+func (s *stubRepo) Delete(id string) error {
+	s.deleted = id
+	return s.deleteErr
+}
+
+func TestRegisterUserSuccess(t *testing.T) {
+	repo := &stubRepo{}
+	uc := NewUserUseCase(repo)
+
+	u, err := uc.RegisterUser("Jon", "jon@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u == nil || u.ID == "" {
+		t.Fatal("user not created")
+	}
+	if repo.saved == nil || repo.saved.Email != "jon@example.com" {
+		t.Fatal("user was not saved")
+	}
+	if time.Since(repo.saved.CreatedAt) > time.Second {
+		t.Error("created time not set correctly")
+	}
+}
+
+func TestRegisterUserInvalidEmail(t *testing.T) {
+	repo := &stubRepo{}
+	uc := NewUserUseCase(repo)
+
+	if _, err := uc.RegisterUser("Jon", "invalid"); err == nil {
+		t.Fatal("expected error")
+	}
+	if repo.saved != nil {
+		t.Error("user should not be saved")
+	}
+}
+
+func TestRegisterUserRepoError(t *testing.T) {
+	repo := &stubRepo{saveErr: errors.New("save fail")}
+	uc := NewUserUseCase(repo)
+
+	if _, err := uc.RegisterUser("Jon", "jon@example.com"); err == nil {
+		t.Fatal("expected repo error")
+	}
+}
+
+func TestRemoveUser(t *testing.T) {
+	repo := &stubRepo{}
+	uc := NewUserUseCase(repo)
+
+	if err := uc.RemoveUser("123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.deleted != "123" {
+		t.Errorf("expected delete id '123', got %s", repo.deleted)
+	}
+}
+
+func TestRemoveUserRepoError(t *testing.T) {
+	repo := &stubRepo{deleteErr: errors.New("delete fail")}
+	uc := NewUserUseCase(repo)
+
+	if err := uc.RemoveUser("123"); err == nil {
+		t.Fatal("expected repo error")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for `IsValidEmail`
- cover `UserUseCase` behavior via stubbed repository
- test configuration loader defaults and error scenarios

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687857471340832b8f5f3fc738d88a00