### PR TITLE
Add env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment configuration example
+# Copy this file to `.env` and adjust values as needed.
+
+APP_ENV=dev
+PORT=8080
+DATABASE_URL=postgres://user:pass@localhost:5432/dbname?sslmode=disable
+REDIS_URL=redis://localhost:6379/0
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASSWORD=secret

--- a/README.md
+++ b/README.md
@@ -2,3 +2,24 @@
 
 Este repositório apresenta uma estrutura base para APIs em Go.
 Consulte o diretório [`docs`](docs/README.md) para detalhes de arquitetura e instruções de uso.
+
+## Configuração rápida
+
+1. Copie o arquivo `.env.example` para `.env` e ajuste os valores conforme o ambiente:
+   ```bash
+   cp .env.example .env
+   ```
+   Variáveis disponíveis:
+   - `APP_ENV` (dev|prod)
+   - `PORT` (padrão 8080)
+   - `DATABASE_URL` (obrigatória)
+   - `REDIS_URL`
+   - `SMTP_HOST`
+   - `SMTP_PORT` (padrão 587)
+   - `SMTP_USER`
+   - `SMTP_PASSWORD`
+2. Instale as dependências e execute a aplicação:
+   ```bash
+   go mod download
+   go run ./cmd
+   ```


### PR DESCRIPTION
## Summary
- add `.env.example` with common environment variables
- update README with quick configuration instructions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687857aed2f0832bb39d3fbfdbfe1395