### PR TITLE
Update setup instructions and linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: help run dev lint fmt test build docker-dev docker-prod
+.PHONY: help run dev lint fmt test build docker-dev docker-prod setup
 
 help:
 	@echo "Comandos disponíveis:"
 	@echo "  make run          - Executa a API localmente (modo padrão)"
 	@echo "  make dev          - Executa a API com variável ENV=dev"
+	@echo "  make setup        - Prepara o ambiente de desenvolvimento"
 	@echo "  make test         - Executa os testes unitários"
 	@echo "  make lint         - Roda o linter (go vet + staticcheck)"
 	@echo "  make fmt          - Formata o código com go fmt"
@@ -17,12 +18,17 @@ run:
 dev:
 	ENV=dev go run ./cmd/main.go
 
+setup:
+	@cp -n .env.example .env 2>/dev/null || true
+	go mod download
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+
 test:
 	go test ./... -v -cover
 
 lint:
 	go vet ./...
-	staticcheck ./...
+	staticcheck -go 1.24 ./...
 
 fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -3,13 +3,28 @@
 Este repositório apresenta uma estrutura base para APIs em Go.
 Consulte o diretório [`docs`](docs/README.md) para detalhes de arquitetura e instruções de uso.
 
+## Requisitos
+
+- Go 1.20 ou superior
+- Make
+- Ferramentas de lint como [staticcheck](https://staticcheck.io) (instalado via `make setup`)
+
+## Conexões externas
+
+O projeto já inclui integrações para:
+
+- Banco de dados PostgreSQL
+- Cache Redis
+- Envio de emails via SMTP
+
 ## Configuração rápida
 
-1. Copie o arquivo `.env.example` para `.env` e ajuste os valores conforme o ambiente:
+1. Execute o comando abaixo para preparar o ambiente de desenvolvimento:
    ```bash
-   cp .env.example .env
+   make setup
    ```
-   Variáveis disponíveis:
+   Esse passo copia o `.env.example` para `.env` (caso ainda não exista), instala as dependências Go e a ferramenta `staticcheck`.
+2. Ajuste as variáveis no arquivo `.env`:
    - `APP_ENV` (dev|prod)
    - `PORT` (padrão 8080)
    - `DATABASE_URL` (obrigatória)
@@ -18,8 +33,7 @@ Consulte o diretório [`docs`](docs/README.md) para detalhes de arquitetura e in
    - `SMTP_PORT` (padrão 587)
    - `SMTP_USER`
    - `SMTP_PASSWORD`
-2. Instale as dependências e execute a aplicação:
+3. Execute a aplicação:
    ```bash
-   go mod download
-   go run ./cmd
+   make run
    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,11 +43,11 @@ Essas separações reforçam os princípios SOLID, mantendo baixo acoplamento e 
 Cada pasta possui responsabilidade única, facilitando testes unitários e extensões controladas.
 
 ## Como Usar
-1. Clone o projeto e instale as dependências:
+1. Clone o projeto e prepare o ambiente:
    ```bash
 git clone <repo-url>
 cd go-api-template-clean
-go mod download
+make setup
    ```
 2. Configure as variáveis de ambiente conforme `internal/config`:
    - `APP_ENV` (dev|prod)


### PR DESCRIPTION
## Summary
- document project requirements, external integrations and setup steps
- add `setup` target in `Makefile` to install dependencies and tools
- ensure lint uses staticcheck with Go 1.24
- update docs accordingly

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68785a0f9504832b9cb72dfad85dc408