### PR TITLE
Support .env loading at startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.5
 
 require (
 	github.com/go-chi/chi/v5 v5.0.9
+	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-chi/chi/v5 v5.0.9 h1:VxajiKwlmdvAtgpYAWvWrfsyO8WCeALJspE2FJuRvjk=
 github.com/go-chi/chi/v5 v5.0.9/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
 github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+
+	"github.com/joho/godotenv"
 )
 
 // AppConfig holds all configurable parameters of the application. It is loaded
@@ -20,10 +22,27 @@ type AppConfig struct {
 	SMTPPassword string
 }
 
+// loadEnvFile loads environment variables from a file when it exists.
+// It ignores missing files but returns any other error encountered.
+func loadEnvFile(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if err := godotenv.Overload(path); err != nil {
+		return fmt.Errorf("load %s: %w", path, err)
+	}
+	return nil
+}
+
 // LoadConfig reads the required environment variables, sets default values for
 // optional ones and validates mandatory fields. It returns an AppConfig instance
 // ready to be consumed by the application.
 func LoadConfig() (*AppConfig, error) {
+	_ = loadEnvFile(".env")
+
 	cfg := &AppConfig{}
 
 	// Environment the application is running in. Defaults to "dev" when not

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestLoadConfigDefaults(t *testing.T) {
 	t.Setenv("DATABASE_URL", "db")
@@ -30,5 +34,57 @@ func TestLoadConfigInvalidSMTPPort(t *testing.T) {
 	t.Setenv("SMTP_PORT", "bad")
 	if _, err := LoadConfig(); err == nil {
 		t.Fatal("expected error for invalid SMTP_PORT")
+	}
+}
+
+func TestLoadEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("SOME_VAR=value\n"), 0o600)
+	t.Setenv("SOME_VAR", "")
+
+	if err := loadEnvFile(envPath); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := os.Getenv("SOME_VAR"); v != "value" {
+		t.Errorf("expected SOME_VAR to be 'value', got '%s'", v)
+	}
+}
+
+func TestLoadEnvFileMissing(t *testing.T) {
+	if err := loadEnvFile("no-file.env"); err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+}
+
+func TestLoadConfigLoadsDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("DATABASE_URL=db\nAPP_ENV=prod\nPORT=9090\nSMTP_PORT=2525\n"), 0o600)
+
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("APP_ENV", "")
+	t.Setenv("PORT", "")
+	t.Setenv("SMTP_PORT", "")
+
+	cwd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(cwd)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DatabaseURL != "db" {
+		t.Errorf("expected db from .env, got %s", cfg.DatabaseURL)
+	}
+	if cfg.Env != "prod" {
+		t.Errorf("expected prod env, got %s", cfg.Env)
+	}
+	if cfg.Port != "9090" {
+		t.Errorf("expected port 9090, got %s", cfg.Port)
+	}
+	if cfg.SMTPPort != 2525 {
+		t.Errorf("expected smtp port 2525, got %d", cfg.SMTPPort)
 	}
 }


### PR DESCRIPTION
## Summary
- load `.env` automatically in `LoadConfig`
- add helper `loadEnvFile`
- add tests covering env file loading
- include `github.com/joho/godotenv` dependency

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68785e57637c832bbf779f812d6c9d6b