### PR TITLE
Add coverage report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Code coverage profiles and other test artifacts
 *.out
 coverage.*
+coverage/
 *.coverprofile
 profile.cov
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run dev lint fmt test build docker-dev docker-prod setup
+.PHONY: help run dev lint fmt test coverage build docker-dev docker-prod setup
 
 help:
 	@echo "Comandos disponíveis:"
@@ -6,6 +6,7 @@ help:
 	@echo "  make dev          - Executa a API com variável ENV=dev"
 	@echo "  make setup        - Prepara o ambiente de desenvolvimento"
 	@echo "  make test         - Executa os testes unitários"
+	@echo "  make coverage     - Executa testes com relatório de cobertura"
 	@echo "  make lint         - Roda o linter (go vet + staticcheck)"
 	@echo "  make fmt          - Formata o código com go fmt"
 	@echo "  make build        - Compila o binário para o host local"
@@ -25,6 +26,11 @@ setup:
 
 test:
 	go test ./... -v -cover
+
+coverage:
+	mkdir -p coverage
+	go test ./... -coverprofile=coverage/coverage.out
+	go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 
 lint:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ O projeto já inclui integrações para:
    make run
    ```
 
+## Testes e cobertura
+
+Para executar os testes com relatório de cobertura, utilize:
+
+```bash
+make coverage
+```
+O comando gera os arquivos `coverage/coverage.out` e `coverage/coverage.html`.
+
 ## Rotas disponíveis
 
 - `GET /health` retorna o status e a versão da API.


### PR DESCRIPTION
## Summary
- generate coverage report via `make coverage`
- ignore coverage folder
- document coverage command in README

## Testing
- `go test ./...`
- `make coverage`

------
https://chatgpt.com/codex/tasks/task_e_6878650777ec832ba822e2ba94f94a71