### PR TITLE
Implement CLI scaffold parser

### DIFF
--- a/cli/internal/scaffold/generator_test.go
+++ b/cli/internal/scaffold/generator_test.go
@@ -9,7 +9,7 @@ func TestGenerateNilSpec(t *testing.T) {
 }
 
 func TestGenerateOK(t *testing.T) {
-	spec := &ScaffoldSpec{Entity: "Test"}
+	spec := &ScaffoldSpec{EntityName: "Test"}
 	if err := Generate(spec); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cli/internal/scaffold/parser.go
+++ b/cli/internal/scaffold/parser.go
@@ -5,46 +5,105 @@ import (
 	"strings"
 )
 
-// Field represents a simple field in the entity.
-type Field struct {
-	Name string
-	Type string
+// FieldSpec represents a single field of the entity.
+// Type stores the base type (string, float, enum, array, json, ...).
+// Subtype holds any nested information such as array element or enum values.
+type FieldSpec struct {
+	Name    string
+	Type    string
+	Subtype string
+	Raw     string
 }
 
-// Relationship defines associations with other entities.
-type Relationship struct {
-	Name string
-	Type string
+// RelationshipSpec captures an association with another entity.
+type RelationshipSpec struct {
+	Name         string
+	Relationship string
 }
 
-// ScaffoldSpec captures all information required to scaffold a module.
+// ScaffoldSpec aggregates all parsed information about an entity.
 type ScaffoldSpec struct {
-	Entity        string
-	Fields        []Field
-	Relationships []Relationship
+	EntityName    string
+	Fields        []FieldSpec
+	Relationships []RelationshipSpec
 }
 
 // Parse interprets CLI arguments into a ScaffoldSpec.
+// It expects at least the entity name followed by field or relationship
+// declarations in the format "name:type".
 func Parse(args []string) (*ScaffoldSpec, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("no entity provided")
 	}
-	spec := &ScaffoldSpec{Entity: args[0]}
+
+	spec := &ScaffoldSpec{EntityName: args[0]}
+
 	for _, a := range args[1:] {
-		parts := strings.SplitN(a, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid argument %q", a)
+		f, r, err := parseArg(a)
+		if err != nil {
+			return nil, err
 		}
-		name, typ := parts[0], parts[1]
-		if isRelationshipType(typ) {
-			spec.Relationships = append(spec.Relationships, Relationship{Name: name, Type: typ})
-		} else {
-			spec.Fields = append(spec.Fields, Field{Name: name, Type: typ})
+		if f != nil {
+			spec.Fields = append(spec.Fields, *f)
+		} else if r != nil {
+			spec.Relationships = append(spec.Relationships, *r)
 		}
 	}
+
 	return spec, nil
 }
 
+// parseArg analyses a single CLI argument and decides whether it describes a
+// field or a relationship. It returns the resulting specification or an error
+// when the syntax is invalid.
+func parseArg(arg string) (*FieldSpec, *RelationshipSpec, error) {
+	parts := strings.SplitN(arg, ":", 2)
+	if len(parts) != 2 {
+		return nil, nil, fmt.Errorf("invalid argument %q", arg)
+	}
+
+	name := parts[0]
+	typ := parts[1]
+
+	if isRelationshipType(typ) {
+		return nil, &RelationshipSpec{Name: name, Relationship: typ}, nil
+	}
+
+	fieldType, subtype, err := splitType(typ)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f := &FieldSpec{
+		Name:    name,
+		Type:    fieldType,
+		Subtype: subtype,
+		Raw:     typ,
+	}
+
+	return f, nil, nil
+}
+
+// splitType breaks a complex type string like "enum[a,b]" or "array[string]" in
+// its base type and subtype. When no subtype is present the subtype will be an
+// empty string.
+func splitType(t string) (string, string, error) {
+	if idx := strings.Index(t, "["); idx != -1 {
+		if !strings.HasSuffix(t, "]") {
+			return "", "", fmt.Errorf("invalid type %q", t)
+		}
+		return t[:idx], t[idx+1 : len(t)-1], nil
+	}
+	return t, "", nil
+}
+
+// isRelationshipType reports whether the given type token represents a
+// relationship declaration instead of a field.
 func isRelationshipType(t string) bool {
-	return t == "belongsTo"
+	switch t {
+	case "belongsTo", "hasMany", "hasOne", "manyToMany":
+		return true
+	default:
+		return false
+	}
 }

--- a/cli/internal/scaffold/parser_test.go
+++ b/cli/internal/scaffold/parser_test.go
@@ -8,7 +8,7 @@ func TestParseSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if spec.Entity != "Invoice" || len(spec.Fields) != 1 || len(spec.Relationships) != 1 {
+	if spec.EntityName != "Invoice" || len(spec.Fields) != 1 || len(spec.Relationships) != 1 {
 		t.Fatalf("parsed spec not as expected: %+v", spec)
 	}
 }
@@ -22,5 +22,50 @@ func TestParseInvalidArg(t *testing.T) {
 func TestParseNoEntity(t *testing.T) {
 	if _, err := Parse([]string{}); err == nil {
 		t.Fatal("expected error for missing entity")
+	}
+}
+
+func TestParseComplexSpec(t *testing.T) {
+	args := []string{
+		"Invoice",
+		"number:string",
+		"total:float",
+		"status:enum[pending,paid]",
+		"tags:array[string]",
+		"metadata:json",
+		"user:belongsTo",
+	}
+	spec, err := Parse(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spec.Fields) != 5 {
+		t.Fatalf("expected 5 fields, got %d", len(spec.Fields))
+	}
+	if len(spec.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(spec.Relationships))
+	}
+	enumField := spec.Fields[2]
+	if enumField.Type != "enum" || enumField.Subtype != "pending,paid" {
+		t.Fatalf("unexpected enum field parsing: %+v", enumField)
+	}
+}
+
+func TestParseArgFunction(t *testing.T) {
+	f, r, err := parseArg("user:belongsTo")
+	if err != nil || f != nil || r == nil {
+		t.Fatalf("expected relationship parse, got f=%v r=%v err=%v", f, r, err)
+	}
+
+	f, r, err = parseArg("status:enum[pending,paid]")
+	if err != nil || r != nil || f == nil {
+		t.Fatalf("expected field parse, got f=%v r=%v err=%v", f, r, err)
+	}
+	if f.Type != "enum" || f.Subtype != "pending,paid" {
+		t.Fatalf("unexpected field result: %+v", f)
+	}
+
+	if _, _, err = parseArg("badarg"); err == nil {
+		t.Fatal("expected error for bad argument")
 	}
 }

--- a/cli/internal/scaffold/updater_test.go
+++ b/cli/internal/scaffold/updater_test.go
@@ -9,7 +9,7 @@ func TestUpdateNilSpec(t *testing.T) {
 }
 
 func TestUpdateOK(t *testing.T) {
-	spec := &ScaffoldSpec{Entity: "Test"}
+	spec := &ScaffoldSpec{EntityName: "Test"}
 	if err := Update(spec); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- define rich `ScaffoldSpec` with `FieldSpec` and `RelationshipSpec`
- parse Rails-like CLI arguments to populate this spec
- extend parser tests and adjust generator/updater tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687871ec74c8832bb9acb9ac4d4c01de