### PR TITLE
Add scaffold templates for unit tests

### DIFF
--- a/cli/internal/scaffold/generator.go
+++ b/cli/internal/scaffold/generator.go
@@ -46,12 +46,14 @@ func Generate(spec *ScaffoldSpec) error {
 	data := buildTemplateData(spec)
 
 	files := map[string]string{
-		"entity.tmpl":     filepath.Join("internal/domain/entity", formatter.ToSnake(spec.EntityName)+".go"),
-		"repository.tmpl": filepath.Join("internal/domain/repository", formatter.ToSnake(spec.EntityName)+"_repository.go"),
-		"service.tmpl":    filepath.Join("internal/domain/service", formatter.ToSnake(spec.EntityName)+"_service.go"),
-		"usecase.tmpl":    filepath.Join("internal/domain/usecase", formatter.ToSnake(spec.EntityName)+"_usecase.go"),
-		"handler.tmpl":    filepath.Join("internal/handler/http", formatter.ToSnake(spec.EntityName)+"_handler.go"),
-		"test.tmpl":       filepath.Join("internal/handler/http", formatter.ToSnake(spec.EntityName)+"_handler_test.go"),
+		"entity.tmpl":          filepath.Join("internal/domain/entity", formatter.ToSnake(spec.EntityName)+".go"),
+		"repository.tmpl":      filepath.Join("internal/domain/repository", formatter.ToSnake(spec.EntityName)+"_repository.go"),
+		"service.tmpl":         filepath.Join("internal/domain/service", formatter.ToSnake(spec.EntityName)+"_service.go"),
+		"usecase.tmpl":         filepath.Join("internal/domain/usecase", formatter.ToSnake(spec.EntityName)+"_usecase.go"),
+		"handler.tmpl":         filepath.Join("internal/handler/http", formatter.ToSnake(spec.EntityName)+"_handler.go"),
+		"handler_test.tmpl":    filepath.Join("internal/handler/http", formatter.ToSnake(spec.EntityName)+"_handler_test.go"),
+		"usecase_test.tmpl":    filepath.Join("internal/domain/usecase", formatter.ToSnake(spec.EntityName)+"_usecase_test.go"),
+		"mock_repository.tmpl": filepath.Join("mocks", formatter.ToSnake(spec.EntityName)+"_repository_mock.go"),
 	}
 
 	for tmpl, dest := range files {

--- a/cli/internal/scaffold/generator_test.go
+++ b/cli/internal/scaffold/generator_test.go
@@ -23,8 +23,17 @@ func TestGenerateOK(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join("internal/domain/entity", "test.go")); err != nil {
-		t.Fatalf("expected file not created: %v", err)
+	paths := []string{
+		filepath.Join("internal/domain/entity", "test.go"),
+		filepath.Join("internal/domain/usecase", "test_usecase_test.go"),
+		filepath.Join("internal/handler/http", "test_handler_test.go"),
+		filepath.Join("mocks", "test_repository_mock.go"),
+	}
+
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected file %s not created: %v", p, err)
+		}
 	}
 }
 

--- a/cli/internal/scaffold/templates/handler_test.tmpl
+++ b/cli/internal/scaffold/templates/handler_test.tmpl
@@ -1,0 +1,129 @@
+package http
+
+import (
+    "bytes"
+    "context"
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/go-chi/chi/v5"
+    "github.com/rgomids/go-api-template-clean/internal/domain/entity"
+)
+
+type fake{{.Entity}}UseCase struct {
+    createFn func(*entity.{{.Entity}}) (*entity.{{.Entity}}, error)
+    getFn    func(string) (*entity.{{.Entity}}, error)
+    listFn   func() ([]*entity.{{.Entity}}, error)
+    updateFn func(string, *entity.{{.Entity}}) (*entity.{{.Entity}}, error)
+    deleteFn func(string) error
+}
+
+func (f *fake{{.Entity}}UseCase) Create(e *entity.{{.Entity}}) (*entity.{{.Entity}}, error) {
+    if f.createFn != nil { return f.createFn(e) }
+    return e, nil
+}
+func (f *fake{{.Entity}}UseCase) GetByID(id string) (*entity.{{.Entity}}, error) {
+    if f.getFn != nil { return f.getFn(id) }
+    return &entity.{{.Entity}}{}, nil
+}
+func (f *fake{{.Entity}}UseCase) List() ([]*entity.{{.Entity}}, error) {
+    if f.listFn != nil { return f.listFn() }
+    return []*entity.{{.Entity}}{}, nil
+}
+func (f *fake{{.Entity}}UseCase) Update(id string, e *entity.{{.Entity}}) (*entity.{{.Entity}}, error) {
+    if f.updateFn != nil { return f.updateFn(id, e) }
+    return e, nil
+}
+func (f *fake{{.Entity}}UseCase) Delete(id string) error {
+    if f.deleteFn != nil { return f.deleteFn(id) }
+    return nil
+}
+
+func Test{{.Entity}}HandlerCreate(t *testing.T) {
+    cases := []struct {
+        name     string
+        body     string
+        usecase  *fake{{.Entity}}UseCase
+        wantCode int
+    }{
+        {"success", `{}`, &fake{{.Entity}}UseCase{}, http.StatusCreated},
+        {"bad payload", `{"`, &fake{{.Entity}}UseCase{}, http.StatusBadRequest},
+        {"usecase error", `{}`, &fake{{.Entity}}UseCase{createFn: func(*entity.{{.Entity}}) (*entity.{{.Entity}}, error) { return nil, errors.New("fail") }}, http.StatusInternalServerError},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            h := New{{.Entity}}Handler(tc.usecase)
+            req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(tc.body))
+            rr := httptest.NewRecorder()
+            h.Create(rr, req)
+            if rr.Code != tc.wantCode {
+                t.Fatalf("expected %d, got %d", tc.wantCode, rr.Code)
+            }
+        })
+    }
+}
+
+func Test{{.Entity}}HandlerGetByID(t *testing.T) {
+    h := New{{.Entity}}Handler(&fake{{.Entity}}UseCase{})
+    req := httptest.NewRequest(http.MethodGet, "/1", nil)
+    ctx := chi.NewRouteContext()
+    ctx.URLParams.Add("id", "1")
+    req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+    rr := httptest.NewRecorder()
+    h.GetByID(rr, req)
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+}
+
+func Test{{.Entity}}HandlerList(t *testing.T) {
+    h := New{{.Entity}}Handler(&fake{{.Entity}}UseCase{})
+    req := httptest.NewRequest(http.MethodGet, "/", nil)
+    rr := httptest.NewRecorder()
+    h.List(rr, req)
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+}
+
+func Test{{.Entity}}HandlerUpdate(t *testing.T) {
+    cases := []struct {
+        name     string
+        body     string
+        usecase  *fake{{.Entity}}UseCase
+        wantCode int
+    }{
+        {"success", `{}`, &fake{{.Entity}}UseCase{}, http.StatusOK},
+        {"bad payload", `{"`, &fake{{.Entity}}UseCase{}, http.StatusBadRequest},
+        {"usecase error", `{}`, &fake{{.Entity}}UseCase{updateFn: func(string, *entity.{{.Entity}}) (*entity.{{.Entity}}, error) { return nil, errors.New("fail") }}, http.StatusInternalServerError},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            h := New{{.Entity}}Handler(tc.usecase)
+            req := httptest.NewRequest(http.MethodPut, "/1", bytes.NewBufferString(tc.body))
+            ctx := chi.NewRouteContext()
+            ctx.URLParams.Add("id", "1")
+            req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+            rr := httptest.NewRecorder()
+            h.Update(rr, req)
+            if rr.Code != tc.wantCode {
+                t.Fatalf("expected %d, got %d", tc.wantCode, rr.Code)
+            }
+        })
+    }
+}
+
+func Test{{.Entity}}HandlerDelete(t *testing.T) {
+    h := New{{.Entity}}Handler(&fake{{.Entity}}UseCase{})
+    req := httptest.NewRequest(http.MethodDelete, "/1", nil)
+    ctx := chi.NewRouteContext()
+    ctx.URLParams.Add("id", "1")
+    req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+    rr := httptest.NewRecorder()
+    h.Delete(rr, req)
+    if rr.Code != http.StatusNoContent {
+        t.Fatalf("expected 204, got %d", rr.Code)
+    }
+}

--- a/cli/internal/scaffold/templates/mock_repository.tmpl
+++ b/cli/internal/scaffold/templates/mock_repository.tmpl
@@ -1,0 +1,30 @@
+package mocks
+
+import "github.com/rgomids/go-api-template-clean/internal/domain/entity"
+
+type Mock{{.Entity}}Repository struct {
+    SaveFn     func(*entity.{{.Entity}}) error
+    FindByIDFn func(string) (*entity.{{.Entity}}, error)
+    DeleteFn   func(string) error
+}
+
+func (m *Mock{{.Entity}}Repository) Save(e *entity.{{.Entity}}) error {
+    if m.SaveFn != nil {
+        return m.SaveFn(e)
+    }
+    return nil
+}
+
+func (m *Mock{{.Entity}}Repository) FindByID(id string) (*entity.{{.Entity}}, error) {
+    if m.FindByIDFn != nil {
+        return m.FindByIDFn(id)
+    }
+    return &entity.{{.Entity}}{}, nil
+}
+
+func (m *Mock{{.Entity}}Repository) Delete(id string) error {
+    if m.DeleteFn != nil {
+        return m.DeleteFn(id)
+    }
+    return nil
+}

--- a/cli/internal/scaffold/templates/usecase_test.tmpl
+++ b/cli/internal/scaffold/templates/usecase_test.tmpl
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+    "errors"
+    "testing"
+
+    "github.com/rgomids/go-api-template-clean/internal/domain/entity"
+)
+
+type Fake{{.Entity}}Repository struct {
+    SaveFn func(*entity.{{.Entity}}) error
+}
+
+func (f *Fake{{.Entity}}Repository) FindByID(id string) (*entity.{{.Entity}}, error) { return nil, nil }
+func (f *Fake{{.Entity}}Repository) Save(e *entity.{{.Entity}}) error {
+    if f.SaveFn != nil {
+        return f.SaveFn(e)
+    }
+    return nil
+}
+func (f *Fake{{.Entity}}Repository) Delete(id string) error { return nil }
+
+func Test{{.Entity}}UseCaseCreate(t *testing.T) {
+    cases := []struct {
+        name    string
+        repo    *Fake{{.Entity}}Repository
+        wantErr bool
+    }{
+        {name: "success", repo: &Fake{{.Entity}}Repository{}},
+        {
+            name:    "save error",
+            repo:    &Fake{{.Entity}}Repository{SaveFn: func(*entity.{{.Entity}}) error { return errors.New("fail") }},
+            wantErr: true,
+        },
+    }
+
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            uc := New{{.Entity}}UseCase(tc.repo)
+            _, err := uc.Create(Fake{{.Entity}}())
+            if tc.wantErr && err == nil {
+                t.Fatal("expected error")
+            }
+            if !tc.wantErr && err != nil {
+                t.Fatalf("unexpected error: %v", err)
+            }
+        })
+    }
+}
+
+func Fake{{.Entity}}() *entity.{{.Entity}} {
+    return &entity.{{.Entity}}{}
+}


### PR DESCRIPTION
## Summary
- extend scaffold generator to create unit test templates
- add handler and usecase test templates
- add repository mock template
- check generation of new files in tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6879b609ac38832bbc6d9a937d77cc6b