### PR TITLE
Use inflection for CLI pluralization

### DIFF
--- a/cli/internal/scaffold/generator.go
+++ b/cli/internal/scaffold/generator.go
@@ -35,12 +35,13 @@ type fieldTemplate struct {
 }
 
 type templateData struct {
-	ImportPath  string
-	EntityName  string
-	TableName   string
-	PluralKebab string
-	Fields      []fieldTemplate
-	HasTime     bool
+	ImportPath   string
+	EntityName   string
+	PluralPascal string
+	PluralSnake  string
+	PluralKebab  string
+	Fields       []fieldTemplate
+	HasTime      bool
 }
 
 // Generate creates the scaffold files for the given spec.
@@ -95,7 +96,8 @@ func generateFile(tmplName, dest string, data templateData) error {
 
 func generateMigrations(spec *ScaffoldSpec, data templateData) error {
 	ts := time.Now().Unix()
-	name := fmt.Sprintf("%d_create_%s_table", ts, formatter.ToSnake(spec.EntityName)+"s")
+	meta := formatter.BuildEntityMeta(spec.EntityName)
+	name := fmt.Sprintf("%d_create_%s_table", ts, meta.PluralSnake)
 	up := filepath.Join("db/migrations", name+".up.sql")
 	down := filepath.Join("db/migrations", name+".down.sql")
 	if err := generateFile("migration_up.tmpl", up, data); err != nil {
@@ -108,11 +110,14 @@ func generateMigrations(spec *ScaffoldSpec, data templateData) error {
 }
 
 func buildTemplateData(spec *ScaffoldSpec) templateData {
+	meta := formatter.BuildEntityMeta(spec.EntityName)
+
 	d := templateData{
-		ImportPath:  modulePath(),
-		EntityName:  toPascal(spec.EntityName),
-		TableName:   formatter.ToSnake(spec.EntityName) + "s",
-		PluralKebab: toKebab(spec.EntityName) + "s",
+		ImportPath:   modulePath(),
+		EntityName:   meta.EntityName,
+		PluralPascal: meta.PluralPascal,
+		PluralSnake:  meta.PluralSnake,
+		PluralKebab:  meta.PluralKebab,
 	}
 	for _, f := range spec.Fields {
 		gt := goType(f)

--- a/cli/internal/scaffold/templates/migration_down.tmpl
+++ b/cli/internal/scaffold/templates/migration_down.tmpl
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS {{ .TableName }};
+DROP TABLE IF EXISTS {{ .PluralSnake }};

--- a/cli/internal/scaffold/templates/migration_up.tmpl
+++ b/cli/internal/scaffold/templates/migration_up.tmpl
@@ -1,4 +1,4 @@
-CREATE TABLE {{ .TableName }} (
+CREATE TABLE {{ .PluralSnake }} (
 id UUID PRIMARY KEY,
 {{- range .Fields }}
 {{ .ColumnName }} {{ .SQLType }},

--- a/cli/internal/scaffold/updater.go
+++ b/cli/internal/scaffold/updater.go
@@ -43,7 +43,8 @@ func updateRoutes(spec *ScaffoldSpec) error {
 	content := string(b)
 	marker := "// [AUTO-GENERATED-ROUTES]"
 
-	route := fmt.Sprintf("/%ss", formatter.ToSnake(spec.EntityName))
+	meta := formatter.BuildEntityMeta(spec.EntityName)
+	route := fmt.Sprintf("/%s", meta.PluralKebab)
 	if strings.Contains(content, route) {
 		return nil
 	}

--- a/cli/pkg/formatter/formatter.go
+++ b/cli/pkg/formatter/formatter.go
@@ -1,6 +1,32 @@
 package formatter
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/iancoleman/strcase"
+	"github.com/jinzhu/inflection"
+)
+
+// EntityMeta aggregates formatted names for an entity.
+type EntityMeta struct {
+	EntityName   string // PascalCase singular
+	PluralPascal string // PascalCase plural
+	PluralSnake  string // snake_case plural
+	PluralKebab  string // kebab-case plural
+}
+
+// BuildEntityMeta formats the entity name and infers its plural form using the
+// inflection library.
+func BuildEntityMeta(name string) EntityMeta {
+	plural := inflection.Plural(name)
+
+	return EntityMeta{
+		EntityName:   strcase.ToCamel(name),
+		PluralPascal: strcase.ToCamel(plural),
+		PluralSnake:  strcase.ToSnake(plural),
+		PluralKebab:  strcase.ToKebab(plural),
+	}
+}
 
 // ToSnake converts a CamelCase string into snake_case.
 func ToSnake(s string) string {

--- a/cli/pkg/formatter/formatter_test.go
+++ b/cli/pkg/formatter/formatter_test.go
@@ -10,3 +10,27 @@ func TestToSnake(t *testing.T) {
 		t.Errorf("unexpected result for lower")
 	}
 }
+
+func TestBuildEntityMeta(t *testing.T) {
+	meta := BuildEntityMeta("library")
+	if meta.PluralPascal != "Libraries" {
+		t.Errorf("expected Libraries, got %s", meta.PluralPascal)
+	}
+	if meta.PluralSnake != "libraries" {
+		t.Errorf("expected libraries, got %s", meta.PluralSnake)
+	}
+	if meta.PluralKebab != "libraries" {
+		t.Errorf("expected libraries, got %s", meta.PluralKebab)
+	}
+
+	meta = BuildEntityMeta("person")
+	if meta.PluralPascal != "People" {
+		t.Errorf("expected People, got %s", meta.PluralPascal)
+	}
+	if meta.PluralSnake != "people" {
+		t.Errorf("expected people, got %s", meta.PluralSnake)
+	}
+	if meta.EntityName != "Person" {
+		t.Errorf("expected Person, got %s", meta.EntityName)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,6 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-chi/chi/v5 v5.0.9 h1:VxajiKwlmdvAtgpYAWvWrfsyO8WCeALJspE2FJuRvjk=
 github.com/go-chi/chi/v5 v5.0.9/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=


### PR DESCRIPTION
## Summary
- add inflection-based EntityMeta builder
- use the plural forms in generator and updater logic
- update migration templates accordingly
- add unit tests for new formatter logic
- tidy go.mod with new deps

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c20e3d174832ba5aa41210c995fb7