### PR TITLE
Update CLI scaffold to full CRUD

### DIFF
--- a/cli/internal/scaffold/generator_test.go
+++ b/cli/internal/scaffold/generator_test.go
@@ -29,6 +29,7 @@ func TestGenerateOK(t *testing.T) {
 		filepath.Join("internal/handler/http", "test_handler_test.go"),
 		filepath.Join("mocks", "test_repository_mock.go"),
 		filepath.Join("internal/app", "test_factory.go"),
+		filepath.Join("internal/infra/db", "test_repository_pg.go"),
 	}
 
 	for _, p := range paths {
@@ -49,10 +50,13 @@ func TestHelpers(t *testing.T) {
 	if sqlType(FieldSpec{Type: "json"}) != "jsonb" {
 		t.Errorf("sqlType json failed")
 	}
+	if sqlType(FieldSpec{Type: "uuid"}) != "uuid" {
+		t.Errorf("sqlType uuid failed")
+	}
 
-	spec := &ScaffoldSpec{EntityName: "log", Fields: []FieldSpec{{Name: "created", Type: "time"}}}
+	spec := &ScaffoldSpec{EntityName: "log"}
 	data := buildTemplateData(spec)
 	if !data.HasTime {
-		t.Errorf("expected HasTime for time fields")
+		t.Errorf("expected HasTime true")
 	}
 }

--- a/cli/internal/scaffold/templates/entity.tmpl
+++ b/cli/internal/scaffold/templates/entity.tmpl
@@ -1,11 +1,11 @@
 package entity
 
-{{- if .HasTime }}
 import "time"
-{{- end }}
 
 type {{ .EntityName }} struct {
+    ID string `json:"id"`
 {{- range .Fields }}
-{{ .Name }} {{ .GoType }} `json:"{{ .JSONName }}"`
+    {{ .Name }} {{ .GoType }} `json:"{{ .JSONName }}"`
 {{- end }}
+    CreatedAt time.Time `json:"created_at"`
 }

--- a/cli/internal/scaffold/templates/factory.tmpl
+++ b/cli/internal/scaffold/templates/factory.tmpl
@@ -10,8 +10,12 @@ import (
 
 type dummy{{ .EntityName }}Repository struct{}
 
-func (d *dummy{{ .EntityName }}Repository) FindByID(id string) (*entity.{{ .EntityName }}, error) { return nil, nil }
+func (d *dummy{{ .EntityName }}Repository) FindByID(id string) (*entity.{{ .EntityName }}, error) { return &entity.{{ .EntityName }}{}, nil }
+func (d *dummy{{ .EntityName }}Repository) List(filters map[string]interface{}) ([]*entity.{{ .EntityName }}, error) {
+    return []*entity.{{ .EntityName }}{}, nil
+}
 func (d *dummy{{ .EntityName }}Repository) Save(e *entity.{{ .EntityName }}) error { return nil }
+func (d *dummy{{ .EntityName }}Repository) Update(id string, e *entity.{{ .EntityName }}) error { return nil }
 func (d *dummy{{ .EntityName }}Repository) Delete(id string) error { return nil }
 
 func New{{ .EntityName }}Repository() domainrepo.{{ .EntityName }}Repository {

--- a/cli/internal/scaffold/templates/handler.tmpl
+++ b/cli/internal/scaffold/templates/handler.tmpl
@@ -1,7 +1,11 @@
 package http
 
 import (
+    "encoding/json"
     "net/http"
+
+    "github.com/go-chi/chi/v5"
+    "{{ .ImportPath }}/internal/domain/entity"
     "{{ .ImportPath }}/internal/domain/service"
 )
 
@@ -13,8 +17,61 @@ func New{{ .EntityName }}Handler(s service.{{ .EntityName }}Service) *{{ .Entity
     return &{{ .EntityName }}Handler{service: s}
 }
 
-func (h *{{ .EntityName }}Handler) Create(w http.ResponseWriter, r *http.Request) {}
-func (h *{{ .EntityName }}Handler) GetByID(w http.ResponseWriter, r *http.Request) {}
-func (h *{{ .EntityName }}Handler) List(w http.ResponseWriter, r *http.Request) {}
-func (h *{{ .EntityName }}Handler) Update(w http.ResponseWriter, r *http.Request) {}
-func (h *{{ .EntityName }}Handler) Delete(w http.ResponseWriter, r *http.Request) {}
+func (h *{{ .EntityName }}Handler) Create(w http.ResponseWriter, r *http.Request) {
+    var e entity.{{ .EntityName }}
+    if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+        writeError(w, http.StatusBadRequest, "invalid body")
+        return
+    }
+    if err := h.service.Create(&e); err != nil {
+        writeError(w, http.StatusInternalServerError, err.Error())
+        return
+    }
+    writeJSON(w, http.StatusCreated, e)
+}
+
+func (h *{{ .EntityName }}Handler) GetByID(w http.ResponseWriter, r *http.Request) {
+    id := chi.URLParam(r, "id")
+    e, err := h.service.GetByID(id)
+    if err != nil {
+        writeError(w, http.StatusInternalServerError, err.Error())
+        return
+    }
+    writeJSON(w, http.StatusOK, e)
+}
+
+func (h *{{ .EntityName }}Handler) List(w http.ResponseWriter, r *http.Request) {
+    filters := map[string]interface{}{}
+    for k, v := range r.URL.Query() {
+        filters[k] = v[0]
+    }
+    list, err := h.service.List(filters)
+    if err != nil {
+        writeError(w, http.StatusInternalServerError, err.Error())
+        return
+    }
+    writeJSON(w, http.StatusOK, list)
+}
+
+func (h *{{ .EntityName }}Handler) Update(w http.ResponseWriter, r *http.Request) {
+    id := chi.URLParam(r, "id")
+    var e entity.{{ .EntityName }}
+    if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+        writeError(w, http.StatusBadRequest, "invalid body")
+        return
+    }
+    if err := h.service.Update(id, &e); err != nil {
+        writeError(w, http.StatusInternalServerError, err.Error())
+        return
+    }
+    w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *{{ .EntityName }}Handler) Delete(w http.ResponseWriter, r *http.Request) {
+    id := chi.URLParam(r, "id")
+    if err := h.service.Delete(id); err != nil {
+        writeError(w, http.StatusInternalServerError, err.Error())
+        return
+    }
+    w.WriteHeader(http.StatusNoContent)
+}

--- a/cli/internal/scaffold/templates/handler_test.tmpl
+++ b/cli/internal/scaffold/templates/handler_test.tmpl
@@ -1,21 +1,94 @@
 package http
 
 import (
+    "bytes"
+    "context"
     "net/http"
     "net/http/httptest"
-    "strings"
     "testing"
+
+    "github.com/go-chi/chi/v5"
+    "{{ .ImportPath }}/internal/domain/entity"
 )
 
+type stubService struct {
+    createFn func(*entity.{{ .EntityName }}) error
+    getFn    func(string) (*entity.{{ .EntityName }}, error)
+    listFn   func(map[string]interface{}) ([]*entity.{{ .EntityName }}, error)
+    updateFn func(string, *entity.{{ .EntityName }}) error
+    deleteFn func(string) error
+}
+
+func (s *stubService) Create(e *entity.{{ .EntityName }}) error {
+    if s.createFn != nil {
+        return s.createFn(e)
+    }
+    return nil
+}
+func (s *stubService) Update(id string, e *entity.{{ .EntityName }}) error {
+    if s.updateFn != nil { return s.updateFn(id, e) }; return nil }
+func (s *stubService) GetByID(id string) (*entity.{{ .EntityName }}, error) {
+    if s.getFn != nil { return s.getFn(id) }; return &entity.{{ .EntityName }}{}, nil }
+func (s *stubService) List(f map[string]interface{}) ([]*entity.{{ .EntityName }}, error) {
+    if s.listFn != nil { return s.listFn(f) }; return []*entity.{{ .EntityName }}{}, nil }
+func (s *stubService) Delete(id string) error {
+    if s.deleteFn != nil { return s.deleteFn(id) }; return nil }
+
 func Test{{ .EntityName }}Handler_Create(t *testing.T) {
-    handler := New{{ .EntityName }}Handler(nil) // use mocks in real test
-
-    req := httptest.NewRequest(http.MethodPost, "/{{ .PluralKebab }}", strings.NewReader(`{}`))
+    h := New{{ .EntityName }}Handler(&stubService{})
+    req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
     rr := httptest.NewRecorder()
+    h.Create(rr, req)
+    if rr.Code != http.StatusCreated {
+        t.Fatalf("expected 201, got %d", rr.Code)
+    }
+}
 
-    handler.Create(rr, req)
-
+func Test{{ .EntityName }}Handler_List(t *testing.T) {
+    h := New{{ .EntityName }}Handler(&stubService{})
+    req := httptest.NewRequest(http.MethodGet, "/?name=x", nil)
+    rr := httptest.NewRecorder()
+    h.List(rr, req)
     if rr.Code != http.StatusOK {
-        t.Errorf("expected 200, got %d", rr.Code)
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+}
+
+func Test{{ .EntityName }}Handler_GetByID(t *testing.T) {
+    h := New{{ .EntityName }}Handler(&stubService{})
+    req := httptest.NewRequest(http.MethodGet, "/1", nil)
+    ctx := chi.NewRouteContext()
+    ctx.URLParams.Add("id", "1")
+    req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+    rr := httptest.NewRecorder()
+    h.GetByID(rr, req)
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected 200, got %d", rr.Code)
+    }
+}
+
+func Test{{ .EntityName }}Handler_Update(t *testing.T) {
+    h := New{{ .EntityName }}Handler(&stubService{})
+    req := httptest.NewRequest(http.MethodPut, "/1", bytes.NewBufferString(`{}`))
+    ctx := chi.NewRouteContext()
+    ctx.URLParams.Add("id", "1")
+    req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+    rr := httptest.NewRecorder()
+    h.Update(rr, req)
+    if rr.Code != http.StatusNoContent {
+        t.Fatalf("expected 204, got %d", rr.Code)
+    }
+}
+
+func Test{{ .EntityName }}Handler_Delete(t *testing.T) {
+    h := New{{ .EntityName }}Handler(&stubService{})
+    req := httptest.NewRequest(http.MethodDelete, "/1", nil)
+    ctx := chi.NewRouteContext()
+    ctx.URLParams.Add("id", "1")
+    req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
+    rr := httptest.NewRecorder()
+    h.Delete(rr, req)
+    if rr.Code != http.StatusNoContent {
+        t.Fatalf("expected 204, got %d", rr.Code)
     }
 }

--- a/cli/internal/scaffold/templates/migration_up.tmpl
+++ b/cli/internal/scaffold/templates/migration_up.tmpl
@@ -1,7 +1,7 @@
 CREATE TABLE {{ .PluralSnake }} (
 id UUID PRIMARY KEY,
 {{- range .Fields }}
-{{ .ColumnName }} {{ .SQLType }},
+{{ .ColumnName }} {{ .SQLType }},{{if eq .SQLType "text"}}{{if ne .GoType "string"}} -- allowed values: {{ .Subtype }}{{end}}{{end}}
 {{- end }}
 created_at TIMESTAMP NOT NULL DEFAULT now()
 );

--- a/cli/internal/scaffold/templates/mock_repository.tmpl
+++ b/cli/internal/scaffold/templates/mock_repository.tmpl
@@ -3,12 +3,34 @@ package mocks
 import "{{ .ImportPath }}/internal/domain/entity"
 
 type Mock{{ .EntityName }}Repo struct {
-    SaveFn func(*entity.{{ .EntityName }}) error
+    SaveFn   func(*entity.{{ .EntityName }}) error
+    UpdateFn func(string, *entity.{{ .EntityName }}) error
+    FindFn   func(string) (*entity.{{ .EntityName }}, error)
+    ListFn   func(map[string]interface{}) ([]*entity.{{ .EntityName }}, error)
+    DeleteFn func(string) error
 }
 
 func (m *Mock{{ .EntityName }}Repo) Save(e *entity.{{ .EntityName }}) error {
-    if m.SaveFn != nil {
-        return m.SaveFn(e)
-    }
+    if m.SaveFn != nil { return m.SaveFn(e) }
+    return nil
+}
+
+func (m *Mock{{ .EntityName }}Repo) Update(id string, e *entity.{{ .EntityName }}) error {
+    if m.UpdateFn != nil { return m.UpdateFn(id, e) }
+    return nil
+}
+
+func (m *Mock{{ .EntityName }}Repo) FindByID(id string) (*entity.{{ .EntityName }}, error) {
+    if m.FindFn != nil { return m.FindFn(id) }
+    return &entity.{{ .EntityName }}{}, nil
+}
+
+func (m *Mock{{ .EntityName }}Repo) List(f map[string]interface{}) ([]*entity.{{ .EntityName }}, error) {
+    if m.ListFn != nil { return m.ListFn(f) }
+    return []*entity.{{ .EntityName }}{}, nil
+}
+
+func (m *Mock{{ .EntityName }}Repo) Delete(id string) error {
+    if m.DeleteFn != nil { return m.DeleteFn(id) }
     return nil
 }

--- a/cli/internal/scaffold/templates/repository.tmpl
+++ b/cli/internal/scaffold/templates/repository.tmpl
@@ -4,6 +4,8 @@ import "{{ .ImportPath }}/internal/domain/entity"
 
 type {{ .EntityName }}Repository interface {
     Save(e *entity.{{ .EntityName }}) error
+    Update(id string, e *entity.{{ .EntityName }}) error
     FindByID(id string) (*entity.{{ .EntityName }}, error)
+    List(filters map[string]interface{}) ([]*entity.{{ .EntityName }}, error)
     Delete(id string) error
 }

--- a/cli/internal/scaffold/templates/repository_pg.tmpl
+++ b/cli/internal/scaffold/templates/repository_pg.tmpl
@@ -1,0 +1,84 @@
+package db
+
+import (
+    "database/sql"
+    "fmt"
+
+    "{{ .ImportPath }}/internal/domain/entity"
+    "{{ .ImportPath }}/internal/domain/repository"
+)
+
+type rowScanner interface{ Scan(dest ...any) error }
+type rowsScanner interface{ Next() bool; Scan(dest ...any) error; Err() error; Close() error }
+type dbExecutor interface {
+    Exec(query string, args ...any) (sql.Result, error)
+    QueryRow(query string, args ...any) rowScanner
+    Query(query string, args ...any) (rowsScanner, error)
+}
+
+type Postgres{{ .EntityName }}Repository struct { db dbExecutor }
+
+func NewPostgres{{ .EntityName }}Repository(db dbExecutor) *Postgres{{ .EntityName }}Repository {
+    return &Postgres{{ .EntityName }}Repository{db: db}
+}
+
+var _ repository.{{ .EntityName }}Repository = (*Postgres{{ .EntityName }}Repository)(nil)
+
+func (r *Postgres{{ .EntityName }}Repository) FindByID(id string) (*entity.{{ .EntityName }}, error) {
+    const q = `SELECT id{{range .Fields}}, {{.ColumnName}}{{end}}, created_at FROM {{ .PluralSnake }} WHERE id = $1`
+    row := r.db.QueryRow(q, id)
+    var e entity.{{ .EntityName }}
+    if err := row.Scan(&e.ID{{range .Fields}}, &e.{{.Name}}{{end}}, &e.CreatedAt); err != nil {
+        return nil, err
+    }
+    return &e, nil
+}
+
+func (r *Postgres{{ .EntityName }}Repository) Save(e *entity.{{ .EntityName }}) error {
+    const q = `INSERT INTO {{ .PluralSnake }} (id{{range .Fields}}, {{.ColumnName}}{{end}}, created_at) VALUES ($1{{range $i, $f := .Fields}}, ${{add $i 2}}{{end}}, ${{add (len .Fields) 2}})`
+    _, err := r.db.Exec(q, e.ID{{range .Fields}}, e.{{.Name}}{{end}}, e.CreatedAt)
+    return err
+}
+
+func (r *Postgres{{ .EntityName }}Repository) Update(id string, e *entity.{{ .EntityName }}) error {
+    const q = `UPDATE {{ .PluralSnake }} SET {{range $i, $f := .Fields}}{{if $i}}, {{end}}{{ $f.ColumnName }} = ${{add $i 1}}{{end}} WHERE id = ${{add (len .Fields) 1}}`
+    _, err := r.db.Exec(q{{range .Fields}}, e.{{.Name}}{{end}}, id)
+    return err
+}
+
+func (r *Postgres{{ .EntityName }}Repository) Delete(id string) error {
+    const q = `DELETE FROM {{ .PluralSnake }} WHERE id = $1`
+    _, err := r.db.Exec(q, id)
+    return err
+}
+
+func (r *Postgres{{ .EntityName }}Repository) List(filters map[string]interface{}) ([]*entity.{{ .EntityName }}, error) {
+    base := `SELECT id{{range .Fields}}, {{.ColumnName}}{{end}}, created_at FROM {{ .PluralSnake }}`
+    args := []any{}
+    allowed := map[string]struct{}{ {{range .Fields}}"{{ .ColumnName }}": {}, {{end}} }
+    i := 1
+    for k, v := range filters {
+        if _, ok := allowed[k]; !ok { continue }
+        if len(args) == 0 {
+            base += " WHERE "
+        } else {
+            base += " AND "
+        }
+        base += fmt.Sprintf("%s = $%d", k, i)
+        args = append(args, v)
+        i++
+    }
+    rows, err := r.db.Query(base, args...)
+    if err != nil { return nil, err }
+    defer rows.Close()
+
+    var list []*entity.{{ .EntityName }}
+    for rows.Next() {
+        var e entity.{{ .EntityName }}
+        if err := rows.Scan(&e.ID{{range .Fields}}, &e.{{.Name}}{{end}}, &e.CreatedAt); err != nil {
+            return nil, err
+        }
+        list = append(list, &e)
+    }
+    return list, rows.Err()
+}

--- a/cli/internal/scaffold/templates/service.tmpl
+++ b/cli/internal/scaffold/templates/service.tmpl
@@ -4,4 +4,8 @@ import "{{ .ImportPath }}/internal/domain/entity"
 
 type {{ .EntityName }}Service interface {
     Create(e *entity.{{ .EntityName }}) error
+    Update(id string, e *entity.{{ .EntityName }}) error
+    GetByID(id string) (*entity.{{ .EntityName }}, error)
+    List(filters map[string]interface{}) ([]*entity.{{ .EntityName }}, error)
+    Delete(id string) error
 }

--- a/cli/internal/scaffold/templates/usecase.tmpl
+++ b/cli/internal/scaffold/templates/usecase.tmpl
@@ -1,18 +1,53 @@
 package usecase
 
 import (
-"{{ .ImportPath }}/internal/domain/entity"
-"{{ .ImportPath }}/internal/domain/repository"
+    "crypto/rand"
+    "encoding/hex"
+    "fmt"
+    "io"
+    "time"
+
+    "{{ .ImportPath }}/internal/domain/entity"
+    "{{ .ImportPath }}/internal/domain/repository"
+    "{{ .ImportPath }}/internal/domain/service"
 )
 
 type {{ .EntityName }}UseCase struct {
-repo repository.{{ .EntityName }}Repository
+    repo repository.{{ .EntityName }}Repository
 }
 
 func New{{ .EntityName }}UseCase(r repository.{{ .EntityName }}Repository) *{{ .EntityName }}UseCase {
-return &{{ .EntityName }}UseCase{repo: r}
+    return &{{ .EntityName }}UseCase{repo: r}
 }
 
 func (uc *{{ .EntityName }}UseCase) Create(e *entity.{{ .EntityName }}) error {
-return uc.repo.Save(e)
+    e.ID = generateID()
+    e.CreatedAt = time.Now()
+    return uc.repo.Save(e)
+}
+
+func (uc *{{ .EntityName }}UseCase) Update(id string, e *entity.{{ .EntityName }}) error {
+    return uc.repo.Update(id, e)
+}
+
+func (uc *{{ .EntityName }}UseCase) GetByID(id string) (*entity.{{ .EntityName }}, error) {
+    return uc.repo.FindByID(id)
+}
+
+func (uc *{{ .EntityName }}UseCase) List(filters map[string]interface{}) ([]*entity.{{ .EntityName }}, error) {
+    return uc.repo.List(filters)
+}
+
+func (uc *{{ .EntityName }}UseCase) Delete(id string) error {
+    return uc.repo.Delete(id)
+}
+
+var _ service.{{ .EntityName }}Service = (*{{ .EntityName }}UseCase)(nil)
+
+func generateID() string {
+    b := make([]byte, 16)
+    if _, err := io.ReadFull(rand.Reader, b); err != nil {
+        return fmt.Sprintf("%d", time.Now().UnixNano())
+    }
+    return hex.EncodeToString(b)
 }

--- a/cli/internal/scaffold/templates/usecase_test.tmpl
+++ b/cli/internal/scaffold/templates/usecase_test.tmpl
@@ -1,60 +1,43 @@
-package usecase_test
+package usecase
 
 import (
     "errors"
     "testing"
+    "time"
 
     "{{ .ImportPath }}/internal/domain/entity"
-    "{{ .ImportPath }}/internal/domain/usecase"
 )
 
 type fakeRepo struct {
     saveFn   func(*entity.{{ .EntityName }}) error
+    updateFn func(string, *entity.{{ .EntityName }}) error
     findFn   func(string) (*entity.{{ .EntityName }}, error)
+    listFn   func(map[string]interface{}) ([]*entity.{{ .EntityName }}, error)
     deleteFn func(string) error
 }
 
-func (f *fakeRepo) Save(e *entity.{{ .EntityName }}) error {
-    if f.saveFn != nil {
-        return f.saveFn(e)
-    }
-    return nil
-}
-
-func (f *fakeRepo) FindByID(id string) (*entity.{{ .EntityName }}, error) {
-    if f.findFn != nil {
-        return f.findFn(id)
-    }
-    return nil, nil
-}
-
-func (f *fakeRepo) Delete(id string) error {
-    if f.deleteFn != nil {
-        return f.deleteFn(id)
-    }
-    return nil
-}
+func (f *fakeRepo) Save(e *entity.{{ .EntityName }}) error { if f.saveFn != nil { return f.saveFn(e) }; return nil }
+func (f *fakeRepo) Update(id string, e *entity.{{ .EntityName }}) error { if f.updateFn != nil { return f.updateFn(id, e) }; return nil }
+func (f *fakeRepo) FindByID(id string) (*entity.{{ .EntityName }}, error) { if f.findFn != nil { return f.findFn(id) }; return &entity.{{ .EntityName }}{}, nil }
+func (f *fakeRepo) List(fm map[string]interface{}) ([]*entity.{{ .EntityName }}, error) { if f.listFn != nil { return f.listFn(fm) }; return []*entity.{{ .EntityName }}{}, nil }
+func (f *fakeRepo) Delete(id string) error { if f.deleteFn != nil { return f.deleteFn(id) }; return nil }
 
 func Test{{ .EntityName }}UseCase_Create(t *testing.T) {
-    t.Run("success", func(t *testing.T) {
-        repo := &fakeRepo{saveFn: func(e *entity.{{ .EntityName }}) error { return nil }}
-        uc := usecase.New{{ .EntityName }}UseCase(repo)
+    repo := &fakeRepo{}
+    uc := New{{ .EntityName }}UseCase(repo)
+    e := &entity.{{ .EntityName }}{}
+    if err := uc.Create(e); err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if e.ID == "" || time.Since(e.CreatedAt) > time.Second {
+        t.Fatalf("fields not set")
+    }
+}
 
-        err := uc.Create(&entity.{{ .EntityName }}{})
-        if err != nil {
-            t.Errorf("expected nil, got %v", err)
-        }
-    })
-
-    t.Run("failure", func(t *testing.T) {
-        repo := &fakeRepo{saveFn: func(e *entity.{{ .EntityName }}) error {
-            return errors.New("fail")
-        }}
-        uc := usecase.New{{ .EntityName }}UseCase(repo)
-
-        err := uc.Create(&entity.{{ .EntityName }}{})
-        if err == nil {
-            t.Errorf("expected error, got nil")
-        }
-    })
+func Test{{ .EntityName }}UseCase_RepoError(t *testing.T) {
+    repo := &fakeRepo{saveFn: func(*entity.{{ .EntityName }}) error { return errors.New("fail") }}
+    uc := New{{ .EntityName }}UseCase(repo)
+    if err := uc.Create(&entity.{{ .EntityName }}{}); err == nil {
+        t.Fatal("expected error")
+    }
 }


### PR DESCRIPTION
## Summary
- enhance templates for entity, repository, usecase, handler and others
- add Postgres repository implementation template
- extend generator with helper functions and default time fields
- update tests for generator

## Testing
- `make build-cli`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d30efc2d8832b9d52a371af7d3780