### PR TITLE
Centralize ID generation

### DIFF
--- a/cli/internal/scaffold/templates/usecase.tmpl
+++ b/cli/internal/scaffold/templates/usecase.tmpl
@@ -1,15 +1,12 @@
 package usecase
 
 import (
-    "crypto/rand"
-    "encoding/hex"
-    "fmt"
-    "io"
     "time"
 
     "{{ .ImportPath }}/internal/domain/entity"
     "{{ .ImportPath }}/internal/domain/repository"
     "{{ .ImportPath }}/internal/domain/service"
+    "github.com/rgomids/go-api-template-clean/pkg/util"
 )
 
 type {{ .EntityName }}UseCase struct {
@@ -21,7 +18,7 @@ func New{{ .EntityName }}UseCase(r repository.{{ .EntityName }}Repository) *{{ .
 }
 
 func (uc *{{ .EntityName }}UseCase) Create(e *entity.{{ .EntityName }}) error {
-    e.ID = generateID()
+    e.ID = util.GenerateID()
     e.CreatedAt = time.Now()
     return uc.repo.Save(e)
 }
@@ -44,10 +41,3 @@ func (uc *{{ .EntityName }}UseCase) Delete(id string) error {
 
 var _ service.{{ .EntityName }}Service = (*{{ .EntityName }}UseCase)(nil)
 
-func generateID() string {
-    b := make([]byte, 16)
-    if _, err := io.ReadFull(rand.Reader, b); err != nil {
-        return fmt.Sprintf("%d", time.Now().UnixNano())
-    }
-    return hex.EncodeToString(b)
-}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.24.5
 
 require (
 	github.com/go-chi/chi/v5 v5.0.9
+	github.com/google/uuid v1.6.0
+	github.com/iancoleman/strcase v0.3.0
+	github.com/jinzhu/inflection v1.0.0
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.11.0
 	golang.org/x/text v0.27.0
@@ -12,6 +15,4 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/iancoleman/strcase v0.3.0 // indirect
-	github.com/jinzhu/inflection v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-chi/chi/v5 v5.0.9 h1:VxajiKwlmdvAtgpYAWvWrfsyO8WCeALJspE2FJuRvjk=
 github.com/go-chi/chi/v5 v5.0.9/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/internal/domain/usecase/user_usecase.go
+++ b/internal/domain/usecase/user_usecase.go
@@ -1,15 +1,13 @@
 package usecase
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/rgomids/go-api-template-clean/internal/domain/entity"
 	"github.com/rgomids/go-api-template-clean/internal/domain/repository"
 	"github.com/rgomids/go-api-template-clean/internal/domain/service"
+	"github.com/rgomids/go-api-template-clean/pkg/util"
 )
 
 // UserUseCase implements UserService, orchestrating business logic.
@@ -25,7 +23,7 @@ func NewUserUseCase(repo repository.UserRepository) *UserUseCase {
 // RegisterUser creates a new user after validating the email.
 func (uc *UserUseCase) RegisterUser(name, email string) (*entity.User, error) {
 	user := &entity.User{
-		ID:        generateID(),
+		ID:        util.GenerateID(),
 		Name:      name,
 		Email:     email,
 		CreatedAt: time.Now(),
@@ -48,11 +46,3 @@ func (uc *UserUseCase) RemoveUser(id string) error {
 
 // Ensure UserUseCase satisfies UserService at compile time.
 var _ service.UserService = (*UserUseCase)(nil)
-
-func generateID() string {
-	b := make([]byte, 16)
-	if _, err := io.ReadFull(rand.Reader, b); err != nil {
-		return fmt.Sprintf("%d", time.Now().UnixNano())
-	}
-	return hex.EncodeToString(b)
-}

--- a/internal/domain/usecase/user_usecase_id_test.go
+++ b/internal/domain/usecase/user_usecase_id_test.go
@@ -1,28 +1,18 @@
 package usecase
 
 import (
-	"crypto/rand"
-	"errors"
 	"testing"
+
+	"github.com/rgomids/go-api-template-clean/pkg/util"
 )
 
-type errorReader struct{}
-
-func (errorReader) Read(p []byte) (int, error) { return 0, errors.New("fail") }
-
 func TestGenerateID(t *testing.T) {
-	id := generateID()
-	if len(id) == 0 {
+	id1 := util.GenerateID()
+	if id1 == "" {
 		t.Fatal("expected id")
 	}
-}
-
-func TestGenerateIDError(t *testing.T) {
-	orig := rand.Reader
-	rand.Reader = errorReader{}
-	id := generateID()
-	rand.Reader = orig
-	if id == "" {
-		t.Fatal("fallback id not generated")
+	id2 := util.GenerateID()
+	if id1 == id2 {
+		t.Fatal("ids should be unique")
 	}
 }

--- a/pkg/util/id.go
+++ b/pkg/util/id.go
@@ -1,0 +1,8 @@
+package util
+
+import "github.com/google/uuid"
+
+// GenerateID returns a new UUID string.
+func GenerateID() string {
+	return uuid.NewString()
+}

--- a/pkg/util/id_test.go
+++ b/pkg/util/id_test.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestGenerateID(t *testing.T) {
+	id1 := GenerateID()
+	if id1 == "" {
+		t.Fatal("expected non-empty id")
+	}
+	if _, err := uuid.Parse(id1); err != nil {
+		t.Fatalf("invalid uuid: %v", err)
+	}
+	if id2 := GenerateID(); id1 == id2 {
+		t.Error("expected unique ids")
+	}
+}


### PR DESCRIPTION
## Summary
- add util.GenerateID and tests
- remove duplicated generateID from user usecase
- update CLI templates to use util.GenerateID
- update dependencies for uuid

## Testing
- `make build-cli`
- `make scaffold entity=Book fields="title:string"`
- `make scaffold entity=Author fields="name:string"`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687d36d1b0bc832b96289bc3d33d5e35