### PR TITLE
Centralize scaffolding stubs and DB interfaces

### DIFF
--- a/cli/internal/scaffold/templates/repository_pg.tmpl
+++ b/cli/internal/scaffold/templates/repository_pg.tmpl
@@ -6,19 +6,12 @@ import (
 
     "{{ .ImportPath }}/internal/domain/entity"
     "{{ .ImportPath }}/internal/domain/repository"
+    pdb "{{ .ImportPath }}/pkg/db"
 )
 
-type rowScanner interface{ Scan(dest ...any) error }
-type rowsScanner interface{ Next() bool; Scan(dest ...any) error; Err() error; Close() error }
-type dbExecutor interface {
-    Exec(query string, args ...any) (sql.Result, error)
-    QueryRow(query string, args ...any) rowScanner
-    Query(query string, args ...any) (rowsScanner, error)
-}
+type Postgres{{ .EntityName }}Repository struct { db pdb.DBExecutor }
 
-type Postgres{{ .EntityName }}Repository struct { db dbExecutor }
-
-func NewPostgres{{ .EntityName }}Repository(db dbExecutor) *Postgres{{ .EntityName }}Repository {
+func NewPostgres{{ .EntityName }}Repository(db pdb.DBExecutor) *Postgres{{ .EntityName }}Repository {
     return &Postgres{{ .EntityName }}Repository{db: db}
 }
 

--- a/internal/infra/db/user_repository_pg.go
+++ b/internal/infra/db/user_repository_pg.go
@@ -1,28 +1,18 @@
 package db
 
 import (
-	"database/sql"
-
 	"github.com/rgomids/go-api-template-clean/internal/domain/entity"
 	"github.com/rgomids/go-api-template-clean/internal/domain/repository"
+	dbx "github.com/rgomids/go-api-template-clean/pkg/db"
 )
 
 // PostgresUserRepository implements UserRepository using a PostgreSQL database.
-type dbExecutor interface {
-	Exec(query string, args ...any) (sql.Result, error)
-	QueryRow(query string, args ...any) rowScanner
-}
-
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
 type PostgresUserRepository struct {
-	db dbExecutor
+	db dbx.DBExecutor
 }
 
 // NewPostgresUserRepository creates a repository with the given DB connection.
-func NewPostgresUserRepository(db dbExecutor) *PostgresUserRepository {
+func NewPostgresUserRepository(db dbx.DBExecutor) *PostgresUserRepository {
 	return &PostgresUserRepository{db: db}
 }
 

--- a/internal/infra/db/user_repository_pg_test.go
+++ b/internal/infra/db/user_repository_pg_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rgomids/go-api-template-clean/internal/domain/entity"
+	dbx "github.com/rgomids/go-api-template-clean/pkg/db"
 )
 
 type stubRow struct {
@@ -29,15 +30,17 @@ func (s stubRow) Scan(dest ...any) error {
 }
 
 type stubDB struct {
-	row     rowScanner
+	row     dbx.RowScanner
 	execErr error
 }
+
+func (s *stubDB) Query(query string, args ...any) (*sql.Rows, error) { return nil, nil }
 
 func (s *stubDB) Exec(query string, args ...any) (sql.Result, error) {
 	return nil, s.execErr
 }
 
-func (s *stubDB) QueryRow(query string, args ...any) rowScanner {
+func (s *stubDB) QueryRow(query string, args ...any) dbx.RowScanner {
 	return s.row
 }
 

--- a/pkg/db/db_executor.go
+++ b/pkg/db/db_executor.go
@@ -1,0 +1,9 @@
+package db
+
+import "database/sql"
+
+type DBExecutor interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) RowScanner
+	Exec(query string, args ...any) (sql.Result, error)
+}

--- a/pkg/db/row_scanner.go
+++ b/pkg/db/row_scanner.go
@@ -1,0 +1,6 @@
+package db
+
+// RowScanner abstracts scanning a single row result.
+type RowScanner interface {
+	Scan(dest ...any) error
+}

--- a/pkg/testing/stub_service.go
+++ b/pkg/testing/stub_service.go
@@ -1,0 +1,10 @@
+package testing
+
+type StubService[T any] struct {
+	Response T
+	Error    error
+}
+
+func (s *StubService[T]) Execute() (T, error) {
+	return s.Response, s.Error
+}

--- a/pkg/testing/stub_service_test.go
+++ b/pkg/testing/stub_service_test.go
@@ -1,0 +1,26 @@
+package testing
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStubServiceExecute(t *testing.T) {
+	s := StubService[int]{Response: 42}
+	res, err := s.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != 42 {
+		t.Fatalf("expected 42, got %d", res)
+	}
+}
+
+func TestStubServiceExecuteError(t *testing.T) {
+	expectedErr := fmt.Errorf("fail")
+	s := StubService[int]{Error: expectedErr}
+	_, err := s.Execute()
+	if err != expectedErr {
+		t.Fatalf("expected %v, got %v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add generic `StubService` under `pkg/testing`
- introduce `DBExecutor` and `RowScanner` interfaces
- refactor postgres repository to use centralized interfaces
- update repository scaffold template
- add unit tests for new stub service

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d3af32c18832b9d81f8029c26ab6f