### PR TITLE
Centralize stubService for generated tests

### DIFF
--- a/cli/internal/scaffold/templates/handler_test.tmpl
+++ b/cli/internal/scaffold/templates/handler_test.tmpl
@@ -9,33 +9,12 @@ import (
 
     "github.com/go-chi/chi/v5"
     "{{ .ImportPath }}/internal/domain/entity"
+    testutil "github.com/rgomids/go-api-template-clean/pkg/testing"
 )
 
-type stubService struct {
-    createFn func(*entity.{{ .EntityName }}) error
-    getFn    func(string) (*entity.{{ .EntityName }}, error)
-    listFn   func(map[string]interface{}) ([]*entity.{{ .EntityName }}, error)
-    updateFn func(string, *entity.{{ .EntityName }}) error
-    deleteFn func(string) error
-}
-
-func (s *stubService) Create(e *entity.{{ .EntityName }}) error {
-    if s.createFn != nil {
-        return s.createFn(e)
-    }
-    return nil
-}
-func (s *stubService) Update(id string, e *entity.{{ .EntityName }}) error {
-    if s.updateFn != nil { return s.updateFn(id, e) }; return nil }
-func (s *stubService) GetByID(id string) (*entity.{{ .EntityName }}, error) {
-    if s.getFn != nil { return s.getFn(id) }; return &entity.{{ .EntityName }}{}, nil }
-func (s *stubService) List(f map[string]interface{}) ([]*entity.{{ .EntityName }}, error) {
-    if s.listFn != nil { return s.listFn(f) }; return []*entity.{{ .EntityName }}{}, nil }
-func (s *stubService) Delete(id string) error {
-    if s.deleteFn != nil { return s.deleteFn(id) }; return nil }
 
 func Test{{ .EntityName }}Handler_Create(t *testing.T) {
-    h := New{{ .EntityName }}Handler(&stubService{})
+    h := New{{ .EntityName }}Handler(&testutil.CRUDStubService[entity.{{ .EntityName }}]{})
     req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
     rr := httptest.NewRecorder()
     h.Create(rr, req)
@@ -45,7 +24,7 @@ func Test{{ .EntityName }}Handler_Create(t *testing.T) {
 }
 
 func Test{{ .EntityName }}Handler_List(t *testing.T) {
-    h := New{{ .EntityName }}Handler(&stubService{})
+    h := New{{ .EntityName }}Handler(&testutil.CRUDStubService[entity.{{ .EntityName }}]{})
     req := httptest.NewRequest(http.MethodGet, "/?name=x", nil)
     rr := httptest.NewRecorder()
     h.List(rr, req)
@@ -55,7 +34,7 @@ func Test{{ .EntityName }}Handler_List(t *testing.T) {
 }
 
 func Test{{ .EntityName }}Handler_GetByID(t *testing.T) {
-    h := New{{ .EntityName }}Handler(&stubService{})
+    h := New{{ .EntityName }}Handler(&testutil.CRUDStubService[entity.{{ .EntityName }}]{})
     req := httptest.NewRequest(http.MethodGet, "/1", nil)
     ctx := chi.NewRouteContext()
     ctx.URLParams.Add("id", "1")
@@ -68,7 +47,7 @@ func Test{{ .EntityName }}Handler_GetByID(t *testing.T) {
 }
 
 func Test{{ .EntityName }}Handler_Update(t *testing.T) {
-    h := New{{ .EntityName }}Handler(&stubService{})
+    h := New{{ .EntityName }}Handler(&testutil.CRUDStubService[entity.{{ .EntityName }}]{})
     req := httptest.NewRequest(http.MethodPut, "/1", bytes.NewBufferString(`{}`))
     ctx := chi.NewRouteContext()
     ctx.URLParams.Add("id", "1")
@@ -81,7 +60,7 @@ func Test{{ .EntityName }}Handler_Update(t *testing.T) {
 }
 
 func Test{{ .EntityName }}Handler_Delete(t *testing.T) {
-    h := New{{ .EntityName }}Handler(&stubService{})
+    h := New{{ .EntityName }}Handler(&testutil.CRUDStubService[entity.{{ .EntityName }}]{})
     req := httptest.NewRequest(http.MethodDelete, "/1", nil)
     ctx := chi.NewRouteContext()
     ctx.URLParams.Add("id", "1")

--- a/pkg/testing/stub_service.go
+++ b/pkg/testing/stub_service.go
@@ -8,3 +8,49 @@ type StubService[T any] struct {
 func (s *StubService[T]) Execute() (T, error) {
 	return s.Response, s.Error
 }
+
+// CRUDStubService provides default implementations for a CRUD-style service.
+// Each function field can be overridden in tests to customize behavior.
+type CRUDStubService[E any] struct {
+	CreateFn func(*E) error
+	UpdateFn func(string, *E) error
+	GetFn    func(string) (*E, error)
+	ListFn   func(map[string]interface{}) ([]*E, error)
+	DeleteFn func(string) error
+}
+
+func (s *CRUDStubService[E]) Create(e *E) error {
+	if s.CreateFn != nil {
+		return s.CreateFn(e)
+	}
+	return nil
+}
+
+func (s *CRUDStubService[E]) Update(id string, e *E) error {
+	if s.UpdateFn != nil {
+		return s.UpdateFn(id, e)
+	}
+	return nil
+}
+
+func (s *CRUDStubService[E]) GetByID(id string) (*E, error) {
+	if s.GetFn != nil {
+		return s.GetFn(id)
+	}
+	var zero E
+	return &zero, nil
+}
+
+func (s *CRUDStubService[E]) List(f map[string]interface{}) ([]*E, error) {
+	if s.ListFn != nil {
+		return s.ListFn(f)
+	}
+	return []*E{}, nil
+}
+
+func (s *CRUDStubService[E]) Delete(id string) error {
+	if s.DeleteFn != nil {
+		return s.DeleteFn(id)
+	}
+	return nil
+}

--- a/pkg/testing/stub_service_test.go
+++ b/pkg/testing/stub_service_test.go
@@ -24,3 +24,35 @@ func TestStubServiceExecuteError(t *testing.T) {
 		t.Fatalf("expected %v, got %v", expectedErr, err)
 	}
 }
+
+func TestCRUDStubServiceDefaults(t *testing.T) {
+	s := CRUDStubService[int]{}
+	if err := s.Create(nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if _, err := s.GetByID("1"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if _, err := s.List(map[string]interface{}{}); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if err := s.Update("1", nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if err := s.Delete("1"); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestCRUDStubServiceOverrides(t *testing.T) {
+	called := false
+	s := CRUDStubService[int]{
+		CreateFn: func(*int) error { called = true; return fmt.Errorf("fail") },
+	}
+	if err := s.Create(nil); err == nil {
+		t.Fatal("expected error")
+	}
+	if !called {
+		t.Fatal("override not called")
+	}
+}


### PR DESCRIPTION
## Summary
- create generic CRUDStubService in `pkg/testing`
- adapt handler test template to reuse CRUDStubService
- extend stub service unit tests

## Testing
- `go test ./...`
- `make build-cli`
- `make scaffold entity=Book fields="title:string"`

------
https://chatgpt.com/codex/tasks/task_e_687d3ff80230832bb544e353af7023ca