### PR TITLE
Add docker-compose dev environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,20 @@
 
 APP_ENV=dev
 PORT=8080
-DATABASE_URL=postgres://user:pass@localhost:5432/dbname?sslmode=disable
-REDIS_URL=redis://localhost:6379/0
+
+# Database connection settings
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=go_api_dev
+DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=disable
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}/0
+
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=user@example.com

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run dev lint fmt test coverage build docker-dev docker-prod setup build-cli scaffold
+.PHONY: help run dev lint fmt test coverage build docker-dev docker-prod setup build-cli scaffold up down logs ps
 
 CLI_BIN := ./bin/go-api-cli
 
@@ -16,6 +16,10 @@ help:
 	@echo "  make docker-prod  - Builda a imagem Docker de produção"
 	@echo "  make build-cli    - Compila a CLI de scaffolding"
 	@echo "  make scaffold     - Gera código de entidade via CLI"
+	@echo "  make up           - Sobe dependências via docker-compose"
+	@echo "  make down         - Encerra containers do docker-compose"
+	@echo "  make logs         - Visualiza logs dos serviços"
+	@echo "  make ps           - Lista status dos serviços"
 
 run:
 	go run ./cmd/main.go
@@ -58,3 +62,15 @@ docker-dev:
 
 docker-prod:
 	docker build -f infra/docker/Dockerfile.prod -t go-api-template:prod .
+
+up:
+	docker compose -f docker/dev/docker-compose.yml up -d
+
+down:
+	docker compose -f docker/dev/docker-compose.yml down
+
+logs:
+	docker compose -f docker/dev/docker-compose.yml logs -f
+
+ps:
+	docker compose -f docker/dev/docker-compose.yml ps

--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ O projeto já contempla integrações para PostgreSQL, Redis e SMTP.
    make run
    ```
 
+### 🔧 Subir ambiente de desenvolvimento
+
+```bash
+   make up
+```
+
+Banco de dados e Redis serão inicializados com:
+- PostgreSQL: localhost:5432
+- Redis: localhost:6379
+
+Os valores podem ser ajustados copiando `.env.example` para `.env` e editando as
+variáveis `DB_*` e `REDIS_*`. O `docker-compose` lerá essas variáveis para
+configurar os serviços.
+
+Para encerrar:
+
+```bash
+   make down
+```
+
 ## Testes e cobertura
 
 ```bash

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+env_file:
+  - ../../.env
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: go_api_pg
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    ports:
+      - "${DB_PORT}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    container_name: go_api_redis
+    ports:
+      - "${REDIS_PORT}:6379"
+    volumes:
+      - redisdata:/data
+
+volumes:
+  pgdata:
+  redisdata:


### PR DESCRIPTION
## Summary
- add docker compose file for Postgres and Redis development
- document how to start services with Makefile helpers
- move example env variables to `.env.example`
- keep `.env` ignored in git
- fix README instructions and Makefile indentation
- use environment variables from `.env` in docker compose
- reference DB_* vars when building `DATABASE_URL` in `.env.example`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d43d7b6c8832b8f75612342447e6b