### PR TITLE
Add reflex hot-reload for dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CLI_BIN := ./bin/go-api-cli
 help:
 	@echo "Comandos disponíveis:"
 	@echo "  make run          - Executa a API localmente (modo padrão)"
-       @echo "  make dev          - Sobe a API em container com reflex"
+    @echo "  make dev          - Sobe a API em container com reflex"
 	@echo "  make setup        - Prepara o ambiente de desenvolvimento"
 	@echo "  make test         - Executa os testes unitários"
 	@echo "  make coverage     - Executa testes com relatório de cobertura"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CLI_BIN := ./bin/go-api-cli
 help:
 	@echo "Comandos disponíveis:"
 	@echo "  make run          - Executa a API localmente (modo padrão)"
-	@echo "  make dev          - Executa a API com variável ENV=dev"
+       @echo "  make dev          - Sobe a API em container com reflex"
 	@echo "  make setup        - Prepara o ambiente de desenvolvimento"
 	@echo "  make test         - Executa os testes unitários"
 	@echo "  make coverage     - Executa testes com relatório de cobertura"
@@ -25,7 +25,7 @@ run:
 	go run ./cmd/main.go
 
 dev:
-	ENV=dev go run ./cmd/main.go
+	docker compose -f docker/dev/docker-compose.yml run --service-ports app
 
 setup: build build-cli
 	@cp -n .env.example .env 2>/dev/null || true

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -4,6 +4,20 @@ env_file:
   - ../../.env
 
 services:
+  app:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile.dev
+    container_name: go_api_app
+    volumes:
+      - ../..:/app
+      - go-mod-cache:/go/pkg/mod
+    command: reflex -c reflex.conf
+    ports:
+      - "${PORT}:8080"
+    depends_on:
+      - postgres
+      - redis
   postgres:
     image: postgres:15
     container_name: go_api_pg
@@ -27,3 +41,4 @@ services:
 volumes:
   pgdata:
   redisdata:
+  go-mod-cache:

--- a/infra/docker/Dockerfile.dev
+++ b/infra/docker/Dockerfile.dev
@@ -2,4 +2,5 @@
 FROM golang:1.24-alpine
 WORKDIR /app
 COPY . .
+RUN go install github.com/cespare/reflex@latest
 CMD ["go", "run", "./cmd/main.go"]

--- a/reflex.conf
+++ b/reflex.conf
@@ -1,0 +1,3 @@
+# Recompilar e reiniciar sempre que qualquer arquivo .go for alterado
+# Ignora diretórios desnecessários
+-r '\.go$' -R '^vendor/' -R '^\.git/' -- sh -c 'go run ./cmd/main.go'


### PR DESCRIPTION
## Summary
- install reflex in development Dockerfile
- add reflex configuration file
- run app container with reflex using docker-compose
- update Makefile dev target to use container

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d523aa8dc832bac806fa44d4de58f